### PR TITLE
docs: add agy usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ irm https://antigravity.google/cli/install.ps1 | iex
 curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
+## Usage
+
+After installation, start Antigravity CLI by running:
+
+```bash
+agy
+```
+
 ---
 
 ## Authentication


### PR DESCRIPTION
### Context
Funnily enough, neither https://antigravity.google/download#antigravity-cli nor this repository's `README.md` has instructions on _how_ to start using Antigravity.

### Changes
Updated the `README.md`