### PR TITLE
feat(subagents): propose Model parameter for invoke_subagent / define…

### DIFF
--- a/docs/proposals/subagent-model-selection.md
+++ b/docs/proposals/subagent-model-selection.md
@@ -1,0 +1,150 @@
+# Proposal: Per-Subagent Model Selection
+
+**Status:** Draft  
+**Author:** MattBetancourt  
+**Related issue:** (link after opening)
+
+---
+
+## Summary
+
+Add an optional `Model` string parameter to the `invoke_subagent` and
+`define_subagent` tools, allowing callers to specify which model a subagent
+should run on rather than always inheriting the session-level model.
+
+---
+
+## Motivation
+
+Since v1.0.5, users can choose a model at session start (`--model`) or switch
+it mid-session (`/model`). Subagents, however, have no equivalent — they always
+inherit whatever model the parent session is currently using.
+
+This creates friction for several practical agent architectures:
+
+1. **Cost-optimised orchestration.** An orchestrator reasonably runs on a
+   capable model (e.g. `gemini-2.5-pro`), but research and file-scanning
+   subagents only need a fast, cheap model (e.g. `gemini-2.0-flash`). There is
+   currently no way to express this split without the user manually switching
+   models between invocations.
+
+2. **Capability-differentiated pipelines.** Some subtasks benefit from extended
+   thinking (e.g. adversarial security review, complex planning). Spawning one
+   subagent with `claude-sonnet-4-6-thinking` while keeping others on a standard
+   model requires either separate sessions or awkward workarounds.
+
+3. **Model benchmarking.** Running the same prompt against two subagents using
+   different models — for comparison or quality-assurance purposes — is
+   impossible today in a single session.
+
+---
+
+## Proposed API Changes
+
+### `invoke_subagent`
+
+Add an optional `Model` field (same identifiers accepted by `--model` / `/model`):
+
+```diff
+ {
+   "TypeName": "string (required)",
+   "Role": "string (required)",
+   "Prompt": "string (required)",
+-  "Workspace": "inherit | branch | share  (optional, default: inherit)"
++  "Workspace": "inherit | branch | share  (optional, default: inherit)",
++  "Model": "string (optional) — model identifier, e.g. \"gemini-2.0-flash\""
+ }
+```
+
+### `define_subagent`
+
+Add an optional `Model` field that sets the default model for all invocations of
+that subagent type:
+
+```diff
+ {
+   "name": "string (required)",
+   "description": "string (required)",
+   "system_prompt": "string (required)",
+   "enable_mcp_tools": "bool (optional)",
+   "enable_subagent_tools": "bool (optional)",
+-  "enable_write_tools": "bool (optional)"
++  "enable_write_tools": "bool (optional)",
++  "Model": "string (optional) — default model for this subagent type"
+ }
+```
+
+---
+
+## Behaviour Spec
+
+| Scenario | Expected result |
+|---|---|
+| `Model` omitted from both `define_subagent` and `invoke_subagent` | Subagent inherits the parent session's current model (no regression) |
+| `Model` set only in `define_subagent` | All invocations of that type use the specified model |
+| `Model` set only in `invoke_subagent` | That specific invocation uses the specified model |
+| `Model` set in both | `invoke_subagent.Model` takes precedence over `define_subagent.Model` |
+| Invalid/unavailable `Model` value | Fail-fast with a clear error before the subagent starts |
+| Parent session model changes mid-conversation | Subagents without an explicit `Model` inherit the updated session model |
+| `self`-type subagent with `Model` set | Spawns with the specified model, not the parent's |
+
+**Override chain (lowest → highest precedence):**
+
+```
+session default  →  define_subagent.Model  →  invoke_subagent.Model
+```
+
+---
+
+## Example Usage
+
+```jsonc
+// Orchestrator (running on gemini-2.5-pro) spawns two concurrent subagents:
+// one cheap and fast, one with extended thinking.
+{
+  "Subagents": [
+    {
+      "TypeName": "research",
+      "Role": "Quick File Scanner",
+      "Prompt": "List all Python files that import the requests library",
+      "Workspace": "inherit",
+      "Model": "gemini-2.0-flash"
+    },
+    {
+      "TypeName": "self",
+      "Role": "Security Reviewer",
+      "Prompt": "Perform an adversarial OWASP-style security review of the auth module",
+      "Workspace": "branch",
+      "Model": "claude-sonnet-4-6-thinking"
+    }
+  ]
+}
+```
+
+---
+
+## Statusline
+
+No changes are needed to the statusline schema. The existing
+`.model.display_name` field in the statusline payload is already populated
+per-conversation. Subagent conversations will naturally reflect their own model
+in that field when the feature is implemented.
+
+---
+
+## Backwards Compatibility
+
+`Model` is entirely optional. All existing `invoke_subagent` and
+`define_subagent` calls without it continue to behave exactly as today. There
+are no breaking changes.
+
+---
+
+## Out of Scope (follow-up candidates)
+
+- **Capability validation**: checking that the chosen model supports tool-calling
+  before assigning it to a subagent with `enable_write_tools: true`.
+- **TUI surface**: a picker UI for subagent model selection inside the
+  interactive session.
+- **Cost estimation**: pre-launch cost hints when a non-default model is
+  requested.

--- a/docs/proposals/subagent-model-selection.md
+++ b/docs/proposals/subagent-model-selection.md
@@ -99,8 +99,8 @@ session default  →  define_subagent.Model  →  invoke_subagent.Model
 ## Example Usage
 
 ```jsonc
-// Orchestrator (running on gemini-2.5-pro) spawns two concurrent subagents:
-// one cheap and fast, one with extended thinking.
+// Orchestrator (running on Gemini 3.1 Pro) spawns two concurrent subagents:
+// one fast and cheap, one with extended thinking for security analysis.
 {
   "Subagents": [
     {
@@ -108,14 +108,14 @@ session default  →  define_subagent.Model  →  invoke_subagent.Model
       "Role": "Quick File Scanner",
       "Prompt": "List all Python files that import the requests library",
       "Workspace": "inherit",
-      "Model": "gemini-2.0-flash"
+      "Model": "Gemini 3.5 Flash (Low)"
     },
     {
       "TypeName": "self",
       "Role": "Security Reviewer",
       "Prompt": "Perform an adversarial OWASP-style security review of the auth module",
       "Workspace": "branch",
-      "Model": "claude-sonnet-4-6-thinking"
+      "Model": "Claude Sonnet 4.6 (Thinking)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add an optional `Model` string parameter to `invoke_subagent` and `define_subagent`, enabling callers to specify which model a subagent should run on — rather than always inheriting the session-level model.

Full proposal: [`docs/proposals/subagent-model-selection.md`](https://github.com/MattBetancourt/antigravity-cli/blob/feat/subagent-model-selection/docs/proposals/subagent-model-selection.md)

---

## Motivation

Since v1.0.5, `--model` and `/model` let users pick a model at the session level. But subagents have no equivalent — they always inherit the parent session's model with no way to override it.

This blocks three practical architectures:

1. **Cost-optimised orchestration** — an orchestrator reasonably runs on a capable model (e.g. `Gemini 3.1 Pro (High)`), but file-scanning and research subagents only need something fast and cheap (e.g. `Gemini 3.5 Flash (Low)`). There is currently no way to express this split.

2. **Capability-differentiated pipelines** — some subtasks genuinely benefit from extended thinking (adversarial security review, complex planning). Spawning one subagent on `Claude Sonnet 4.6 (Thinking)` while keeping others on a standard model requires either a separate session or awkward workarounds.

3. **Model benchmarking** — running the same prompt against two subagents using different models for comparison is impossible today in a single session.

---

## Proposed API Changes

### `invoke_subagent`

```diff
 {
   "TypeName": "string (required)",
   "Role": "string (required)",
   "Prompt": "string (required)",
-  "Workspace": "inherit | branch | share  (optional, default: inherit)"
+  "Workspace": "inherit | branch | share  (optional, default: inherit)",
+  "Model": "string (optional) — e.g. \"Gemini 3.5 Flash (Low)\""
 }
```

### `define_subagent`

```diff
 {
   "name": "string (required)",
   "description": "string (required)",
   "system_prompt": "string (required)",
   "enable_mcp_tools": "bool (optional)",
   "enable_subagent_tools": "bool (optional)",
-  "enable_write_tools": "bool (optional)"
+  "enable_write_tools": "bool (optional)",
+  "Model": "string (optional) — default model for this subagent type"
 }
```

### Override chain (lowest → highest precedence)

```
session default  →  define_subagent.Model  →  invoke_subagent.Model
```

---

## Behaviour Spec

| Scenario | Expected result |
|---|---|
| `Model` omitted | Inherits session model — no regression |
| `Model` set in `define_subagent` only | All invocations of that type use the specified model |
| `Model` set in `invoke_subagent` only | That specific invocation uses the specified model |
| Both set | `invoke_subagent.Model` takes precedence |
| Invalid model identifier | Fail-fast with a clear error before the subagent starts |
| `self`-type subagent with `Model` | Spawns with the override, not the parent's model |

---

## Example

```jsonc
// Orchestrator (Gemini 3.1 Pro) spawns two concurrent subagents
// with different models suited to their tasks.
{
  "Subagents": [
    {
      "TypeName": "research",
      "Role": "Quick File Scanner",
      "Prompt": "List all Python files that import the requests library",
      "Workspace": "inherit",
      "Model": "Gemini 3.5 Flash (Low)"
    },
    {
      "TypeName": "self",
      "Role": "Security Reviewer",
      "Prompt": "Perform an adversarial OWASP-style review of the auth module",
      "Workspace": "branch",
      "Model": "Claude Sonnet 4.6 (Thinking)"
    }
  ]
}
```

**Currently available models** (as of v1.0.6, via `agy models`):
- `Gemini 3.5 Flash (Low)` / `(Medium)` / `(High)`
- `Gemini 3.1 Pro (Low)` / `(High)`
- `Claude Sonnet 4.6 (Thinking)`
- `Claude Opus 4.6 (Thinking)`
- `GPT-OSS 120B (Medium)`

---

## Backwards Compatibility

`Model` is entirely optional. All existing `invoke_subagent` and `define_subagent` calls without it behave exactly as today — no regressions.

## Out of Scope (follow-up candidates)

- Model capability validation (e.g. checking tool-calling support before assigning a model to a subagent with `enable_write_tools: true`)
- TUI surface for subagent model selection
- Pre-launch cost estimation hints