### PR TITLE
docs: expose machine readable CLI documentation

### DIFF
--- a/builtin/skills/antigravity_guide/references/cli.md
+++ b/builtin/skills/antigravity_guide/references/cli.md
@@ -1,0 +1,41 @@
+# Antigravity CLI (`agy`) Reference
+
+The Antigravity CLI (`agy`) is a lightweight, terminal-based interface for fast
+agent interaction. For full details, always consult the live public
+documentation:
+
+-   **CLI Features & Subagents**: `https://github.com/google-antigravity/antigravity-cli/blob/main/docs/features.md`
+-   **CLI Best Practices**: `https://github.com/google-antigravity/antigravity-cli/blob/main/docs/best-practices.md`
+-   **CLI Reference**: `https://github.com/google-antigravity/antigravity-cli/blob/main/docs/reference.md`
+
+When the user asks about CLI specifics, **fetch the relevant page above** for
+authoritative, up-to-date information.
+
+--------------------------------------------------------------------------------
+
+## 1. Getting Started
+
+-   **Launch**: Run `agy` to start the CLI.
+-   **Authentication**: On first run, follow the on-screen prompts to
+    authenticate. See `https://github.com/google-antigravity/antigravity-cli/blob/main/docs/reference.md` for
+    details.
+-   **Exit**: `Ctrl+D Ctrl+D` (or `/exit` or `/quit`).
+
+--------------------------------------------------------------------------------
+
+## 2. CLI Slash Commands
+
+-   **CLI flags & subcommands**: Run `agy --help` to see all command-line flags
+    and subcommands.
+-   **Slash commands** (inside the TUI): Launch `agy` and run `/help` to see all
+    available slash commands.
+-   **Full reference**: Fetch `https://github.com/google-antigravity/antigravity-cli/blob/main/docs/reference.md`
+    for the authoritative list of all slash commands and CLI options.
+
+--------------------------------------------------------------------------------
+
+## 3. Configuration
+
+The CLI is configured via **`~/.gemini/antigravity-cli/settings.json`**. For the
+full list of settings keys, types, and defaults, fetch the live docs:
+`https://github.com/google-antigravity/antigravity-cli/blob/main/docs/reference.md`

--- a/docs/\.md
+++ b/docs/\.md
@@ -1,0 +1,446 @@
+# ![](https://antigravity.google/assets/image/antigravity-cursor.png) Experience liftoff with the next-gen agent platformExperience liftoff with the next-gen agent platform
+
+Download for Linux  Explore use cases
+
+close
+
+play\_arrowPlay intro
+
+play\_arrow
+
+- merge
+
+- terminal
+
+- commit
+
+- folder
+
+- keyboard\_command\_key
+
+- spark
+
+- spark
+
+- plus\_code
+
+- deployed\_code
+
+- search\_spark
+
+- refresh
+
+- code
+
+- device\_hub
+
+- developer\_mode\_tv
+
+- file\_copy
+
+- dashboard\_customize
+
+- data\_object
+
+- pen\_spark
+
+- keyboard\_tab
+
+- code\_blocks
+
+- keyboard\_return
+
+- check\_circle
+
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Google Antigravity is our agentic development platform, allowing anyone to build in the agent-first era.
+
+G
+
+o
+
+o
+
+g
+
+l
+
+e
+
+A
+
+n
+
+t
+
+i
+
+g
+
+r
+
+a
+
+v
+
+i
+
+t
+
+y
+
+i
+
+s
+
+o
+
+u
+
+r
+
+a
+
+g
+
+e
+
+n
+
+t
+
+i
+
+c
+
+d
+
+e
+
+v
+
+e
+
+l
+
+o
+
+p
+
+m
+
+e
+
+n
+
+t
+
+p
+
+l
+
+a
+
+t
+
+f
+
+o
+
+r
+
+m
+
+,
+
+a
+
+l
+
+l
+
+o
+
+w
+
+i
+
+n
+
+g
+
+a
+
+n
+
+y
+
+o
+
+n
+
+e
+
+t
+
+o
+
+b
+
+u
+
+i
+
+l
+
+d
+
+i
+
+n
+
+t
+
+h
+
+e
+
+a
+
+g
+
+e
+
+n
+
+t
+
+-
+
+f
+
+i
+
+r
+
+s
+
+t
+
+e
+
+r
+
+a
+
+.
+
+Antigravity 2.0
+
+Your command center to manage multiple local agents in parallel. Group conversations into Projects, operate across multiple workspaces, and automate routine tasks with scheduled messages.
+
+![Your command center to manage multiple local agents in parallel. Group conversations into Projects, operate across multiple workspaces, and automate routine tasks with scheduled messages.](https://antigravity.google/assets/image/product/new-chat.png)
+
+Antigravity CLI
+
+The lightweight, fast, terminal-first surface to work with Antigravity agents. Run autonomous coding agents, execute shell commands directly, and manage background subagents all from your keyboard.
+
+![The lightweight, fast, terminal-first surface to work with Antigravity agents. Run autonomous coding agents, execute shell commands directly, and manage background subagents all from your keyboard.](https://antigravity.google/assets/image/landing/antigravity-cli.png)
+
+Antigravity SDK
+
+Prototype custom agents leveraging Antigravity's harness with minimal code. Simple Python scripts to iterate on agentic applications, automate software engineering tasks, and run evaluations on top of the Antigravity agent harness.
+
+![Prototype custom agents leveraging Antigravity's harness with minimal code. Simple Python scripts to iterate on agentic applications, automate software engineering tasks, and run evaluations on top of the Antigravity agent harness.](https://antigravity.google/assets/image/landing/feature-3.jpg)
+
+Antigravity IDE
+
+The fully-featured, agentic IDE. Complete with the agent manager, artifacts, and a deep understanding of your codebase.
+
+[Explore Product](https://antigravity.google/product)
+
+close
+
+## Built for developersfor the agent-first era
+
+Google Antigravity is built for user trust, whether you're a professional developer working in a large enterprise codebase, a hobbyist vibe-coding in their spare time, or anyone in between.
+
+![Full stack developer](https://antigravity.google/assets/image/landing/landing-thumbnail-fullstack.jpg)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Full stack developer
+
+F
+
+u
+
+l
+
+l
+
+s
+
+t
+
+a
+
+c
+
+k
+
+d
+
+e
+
+v
+
+e
+
+l
+
+o
+
+p
+
+e
+
+r
+
+play\_arrow
+
+play\_arrowWatch case
+
+![Enterprise developer](https://antigravity.google/assets/image/landing/landing-thumbnail-enterprise.jpg)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Enterprise developer
+
+E
+
+n
+
+t
+
+e
+
+r
+
+p
+
+r
+
+i
+
+s
+
+e
+
+d
+
+e
+
+v
+
+e
+
+l
+
+o
+
+p
+
+e
+
+r
+
+play\_arrow
+
+play\_arrowWatch case
+
+![Frontend developer](https://antigravity.google/assets/image/landing/landing-thumbnail-frontend.jpg)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Frontend developer
+
+F
+
+r
+
+o
+
+n
+
+t
+
+e
+
+n
+
+d
+
+d
+
+e
+
+v
+
+e
+
+l
+
+o
+
+p
+
+e
+
+r
+
+play\_arrow
+
+play\_arrowWatch case
+
+**Full stack developer**
+
+Build production-ready applications with confidence with thoroughly designed artifacts and comprehensive verification tests.
+
+[View case](https://antigravity.google/use-cases/fullstack)
+
+**Enterprise developer**
+
+Google Antigravity empowers the next era of enterprise builders.
+
+[View case](https://antigravity.google/use-cases/enterprise)
+
+**Frontend developer**
+
+Streamline UX development by leveraging browser-in-the-loop agents to automate repetitive tasks.
+
+[View case](https://antigravity.google/use-cases/frontend)
+
+keyboard\_arrow\_leftkeyboard\_arrow\_right
+
+Available at no charge
+
+For developers
+
+Achieve new heights
+
+Download
+
+Now Available!
+
+For organizations
+
+Level up your entire team
+
+Read More
+
+keyboard\_arrow\_leftkeyboard\_arrow\_right
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+
+[Google](https://www.google.com/)
+
+Manage cookies

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,214 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](product.md)
+
+Products
+
+[antigravity Antigravity 2.0](product-antigravity-2.md) [terminal Antigravity CLI](product-antigravity-cli.md) [code Antigravity IDE](product-antigravity-ide.md) [sdk Antigravity SDK](product.md/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](use-cases.md)
+
+[Enterprise](use-cases.md/enterprise) [Frontend](use-cases-frontend.md) [Fullstack](use-cases.md/fullstack) [Science](use-cases-science.md) [Marketer](use-cases.md/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](docs.md) [Changelog](changelog.md) [Support](support.md) [Press](press.md) [Releases](releases.md)
+
+[Home](docs-home.md)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](docs.md/enterprise)
+
+[Plans](docs.md/plans)
+
+[FAQ](docs.md/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Best Practices
+
+# Best practices for Antigravity CLI [link](\.md#best-practices-for-antigravity-cli)
+
+Master the workflows, prompt architectures, and local configuration choices to maximize agent velocity while maintaining robust control.
+
+## Establish verification loops [link](\.md#establish-verification-loops)
+
+The single most effective way to ensure reliable, correct modifications from an autonomous agent is to provide the agent with a local verification mechanism (such as unit tests, build commands, or formatting scripts).
+
+Before asking the agent to implement a code change:
+
+1. Ensure your workspace directory has a test suite ready.
+2. If tests do not exist, direct the agent to write a standard test block _first_.
+3. Once the agent proposes code, instruct it to run the local test command to verify its work.
+4. Watch the agent execute the command and iterate on the test outputs automatically.
+
+text
+
+content\_copy
+
+```
+            > Implement feature X in main.py. Run npm test afterward to verify the build.
+
+```
+
+## Explore, plan, then execute [link](\.md#explore-plan-then-execute)
+
+Autonomous local agents operate with highest accuracy when complex changes are partitioned into distinct exploration, planning, and execution phases.
+
+- **Exploration**: Ask the agent to explain how the target codebase resolves a particular problem or where an interface is defined before writing any changes.
+- **Planning**: Request an implementation plan. The agent will list targeted files, required dependencies, and logic overrides in an implementation plan artifact.
+- **Execution**: Once you approve the structured plan, direct the agent to apply the edits.
+
+text
+
+content\_copy
+
+```
+            > Explore how our router resolves `/docs/:page`. Write down an implementation plan to add `/docs/best-practices`.
+
+```
+
+## Enrich your prompting context [link](\.md#enrich-your-prompting-context)
+
+Give local agents high-fidelity indicators to narrow down reasoning boundaries and minimize token overhead.
+
+### Target file autocompletion [link](\.md#target-file-autocompletion)
+
+Type `@` within your prompt box to trigger the **Interactive Path Suggestion** overlay. Highlighting and selecting a path imports the absolute workspace file path directly into your prompt. This helps the agent target its code searches.
+
+### Attaching visual evidence [link](\.md#attaching-visual-evidence)
+
+If debugging visual UI issues, rendering bugs, or frontend layout inconsistencies, capture a screenshot or video recording, copy it, and press `ctrl+v` inside the prompt box to attach it. The agent will consult the media file to diagnose the issue.
+
+## Configure your workspace environment [link](\.md#configure-your-workspace-environment)
+
+Optimize your local workstation rules and security boundaries to match your engineering flow.
+
+### Write a codebase rule file [link](\.md#write-a-codebase-rule-file)
+
+Create a `GEMINI.md` or `AGENTS.md` file at your workspace root to outline specific directory standards, styling paradigms, test command parameters, and deprecation warnings. The agent automatically parses these rules on startup and consults them before suggesting changes.
+
+### Establish structured permissions [link](\.md#establish-structured-permissions)
+
+Tune your safety barriers in `~/.gemini/antigravity-cli/settings.json` based on your project risk level:
+
+- **`request-review`** (Default): Prompts you before executing any write operations, bash commands, or remote network calls.
+- **`proceed-in-sandbox`**: Restricts all terminal executions to a secure sandbox containment ring. Safe commands execute autonomously, while risky commands prompt for reviews.
+- **`strict`**: Always prompts for all non-read operations, providing complete line-by-line transparency.
+
+json
+
+content\_copy
+
+```
+            {
+  "toolPermission": "proceed-in-sandbox",
+  "enableTerminalSandbox": true
+}
+
+```
+
+## Manage TUI sessions proactively [link](\.md#manage-tui-sessions-proactively)
+
+Use active session navigation tools to recover from engineering dead-ends or course-correct intermediate agent loops.
+
+### Course-correct early (\`esc\`) [link](\.md#course-correct-early-esc)
+
+If you watch an agent execute an incorrect search pattern or write code that deviates from your intentions, press the global escape hatch key `esc` immediately to interrupt the turn and regain focus of a clean prompt.
+
+### Rewind history with \`/rewind\` [link](\.md#rewind-history-with-rewind)
+
+If an agent has made several successive changes that introduce build errors, you do not need to discard the session. Type `/rewind` (or `/undo`) to roll back your conversation thread to a previous stable checkout.
+
+### Branch experiments with \`/fork\` [link](\.md#branch-experiments-with-fork)
+
+If you are unsure of the best implementation path:
+
+1. Reach a stable baseline thread.
+2. Type `/fork` to spin up a duplicate parallel session.
+3. Test your speculative code modifications in the branched session.
+4. If the approach fails, run `/resume` to swap back to your stable main branch.
+
+## Automate and script [link](\.md#automate-and-script)
+
+Antigravity CLI is designed to operate seamlessly within standard shell pipeline tools.
+
+### Run non-interactive commands (\`-p\`) [link](\.md#run-non-interactive-commands-p)
+
+To automate quick queries or integrate agents into git hooks, use the one-shot prompt flag `-p`:
+
+bash
+
+content\_copy
+
+```
+            agy -p "Review this git diff and draft a conventional commit message" --cwd $(pwd)
+
+```
+
+### Fan out using parallel subagents [link](\.md#fan-out-using-parallel-subagents)
+
+For large-scale sweeps or multi-file refactoring, direct the primary agent to spawn concurrent background subagents. The agent manager handles background threads autonomously while you continue working on your primary screen.
+
+## Related resources [link](\.md#related-resources)
+
+Learn how to configure settings and customize visual layouts:
+
+- **[Settings, Rendering & Keybindings](docs-cli-settings.md)**: Customize keyboard hotkeys and buffers.
+- **[Permissions & Sandbox](docs-cli-sandbox.md)**: Enforce filesystem containment.
+- **[Plugins & Skills](docs.md/cli/plugins)**: Create your own custom slash commands.
+
+[Model Quotas (/usage)](docs.md/cli/commands/usage)
+
+[Troubleshooting](docs.md/cli/troubleshooting)
+
+On this Page
+
+- Best practices for Antigravity CLI
+
+- Establish verification loops
+
+- Explore, plan, then execute
+
+- Enrich your prompting context
+
+- Configure your workspace environment
+
+- Manage TUI sessions proactively
+
+- Automate and script
+
+- Related resources

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,314 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Google Antigravity Changelog
+
+G
+
+o
+
+o
+
+g
+
+l
+
+e
+
+A
+
+n
+
+t
+
+i
+
+g
+
+r
+
+a
+
+v
+
+i
+
+t
+
+y
+
+C
+
+h
+
+a
+
+n
+
+g
+
+e
+
+l
+
+o
+
+g
+
+[View docs](https://antigravity.google/docs)[Follow us on X](https://x.com/antigravity)
+
+Antigravity 2.0  Antigravity IDE
+
+info
+
+New versions are rolled out gradually and may take a few days to reach all users.
+
+Version
+
+Description
+
+* * *
+
+2.3.1
+
+July 16, 2026
+
+### Startup stability fix
+
+Fixes a bug where an empty or malformed configuration file caused AGY to fail to load on startup.
+
+Improvements (0)
+
+Fixes (0)
+
+Patches (1)
+
+- Fixed a bug where an empty or malformed \`config.json\` configuration file in the \`~/.gemini/config/\` directory prevented AGY from loading on startup.
+
+2.3.0
+
+July 13, 2026
+
+### Queued messages, plain text files support, and stability improvements
+
+Added support for queued messages, settings to configure message execution, a send now option, plain text file attachments, and various bug fixes and improvements.
+
+Improvements (10)
+
+- Added support for queued messages with settings to configure execution behavior and a 'Send Now' option for immediate delivery.
+- Added support for attaching and rendering plain text (.txt) files in conversations.
+- Improved startup performance by optimizing file watching.
+- Adjusted the vertical positioning of the comment button in diff views to align better with the code.
+- Improved the layout, count badge, and styling of the Queued Messages card in the chat input area.
+- Improved stability by automatically retrying when encountering intermittent backend overload errors.
+- Improved teamwork reliability by ensuring helper agents do not hang when requesting feedback on created files.
+- Improved application startup performance by optimizing the initialization sequence.
+- Improved command permission prompting by defaulting to strict literal matching, relaxing checks on commands with redirection, and ignoring global wildcards in sandbox configuration.
+- The UI default theme now respects system preferences instead of defaulting to dark mode.
+
+Fixes (5)
+
+- Fixed find-in-page (Cmd+F) search to correctly locate and highlight matches in virtualized file views.
+- Improved side questions (/btw) with persistence across conversation switches, display of the agent's thinking process, and a fix for background retries when closed.
+- Stopped background tasks from continuing to run after a conversation is archived.
+- Fixed an issue where diffs for files with more than 1000 lines rendered incorrectly.
+- Fixed an issue where the agent could hang indefinitely after subagents finished executing.
+
+Patches (0)
+
+2.2.1
+
+June 25, 2026
+
+### Antigravity Guide, audio support, search improvements, and performance fixes
+
+New built-in Antigravity Guide skill, audio file rendering, improved substring file search, performance optimizations, and critical bug fixes.
+
+Improvements (19)
+
+- Added a new built-in Antigravity Guide skill to provide helpful guidance when users ask about Antigravity.
+- Added syntax highlighting for C++, Python, and Protobuf files in markdown code and diff blocks.
+- Added hover tooltips to file pills in the chat and workspace views to display absolute paths and clarify workspace locations.
+- Improved readability of context pills by truncating long labels and adding hover tooltips to view the full content.
+- Enabled automatic saving of refreshed OAuth tokens to the OS keyring to reduce authentication prompts.
+- Added support for rendering and playing audio files (.mp3, .wav, .ogg, .m4a) within the sidebar file viewer and artifact viewer.
+- Added a new 'Conversation Width' setting under Appearance settings, allowing you to configure the maximum width of the conversation panel (Default, Narrow, or Wide).
+- When creating a new project, Antigravity 2.0 will now notify you if a project with the same folders already exists, allowing you to quickly navigate to it.
+- Added a tooltip to show the full task summary when hovering over items in the Running Items panel.
+- Improved the model selector dropdown to dynamically resize and prevent truncation of long model names.
+- Updated the permissions request dialog to display a clear description of the action or command being run.
+- Improved response time and reliability of account status checks when Terms of Service violations are encountered.
+- Improved UI responsiveness and eliminated lag when resizing the sidebar layout.
+- Aligned theme colors, font sizes, text size, and line height in the chat input area to match surrounding UI density and ensure consistent rendering.
+- Improved usability for touch and stylus users by increasing the size of various UI hit targets, including buttons, pills, and toolbars.
+- Adjusted the diff viewer layout to provide more horizontal space for code contents.
+- Added a brief delay before displaying tooltips for long conversation titles in the sidebar.
+- Optimized file watching notifications to prevent visual flickering and improve performance during high-frequency file writes.
+- Updated icons for built-in slash commands and redesigned mentions/slash commands menu alignment in the chat input box.
+
+Fixes (17)
+
+- Fixed an issue with broken text selection anchoring when adding comments to files or artifacts.
+- Fixed an issue where workspace context was lost when navigating to the history page or other views.
+- Fixed performance issues, rendering loops, and lag when navigating folders using the file path breadcrumbs or the file tree.
+- Fixed erratic behavior and lag in slash command autocomplete during network instability.
+- Improved file search in your workspace by matching substrings instead of requiring exact prefix matches.
+- Fixed an issue where file search within workspaces could fail with a 'No such file or directory' error.
+- Fixed an issue where allowing commands with special characters (like dots or environment variables) could trigger an infinite permission prompt loop.
+- Improved command execution permission matching to support prefix-matching for build/test commands and correct handling of quoted arguments.
+- Fixed issues where in-progress prompts and local history edits were discarded during navigation or permission checks.
+- Fixed an issue where custom theme settings and color modes were not correctly applied on startup, including rejecting hex codes with a leading '#' symbol.
+- Fixed startup issues and recurring User Account Control (UAC) prompts on Windows by registering a scheduled task and resolving access control errors on system PATH directories.
+- Fixed crashes and synchronization issues when deleting persistent state across tabs.
+- Improved accessibility and usability of the artifact review dialog, including contrast, tooltips, and error messaging.
+- Fixed an issue where the agent was blocked from reading builtin customizations and skills due to sandbox restrictions.
+- Fixed a startup race condition that could cause duplicate project folders to be created.
+- Fixed a deadlock issue that could cause subagents to hang during execution.
+- Fixed a potential crash when calculating token usage.
+
+Patches (0)
+
+2.1.4
+
+June 11, 2026
+
+### Quota Screen Redesign and PDF Support
+
+Quota screen redesign, PDF attachment support, new /btw slash command, and other bug fixes
+
+Improvements (7)
+
+- Quota screen redesign: clearer, unambiguous view into “used” versus “remaining” credits in the Models tab of the Settings screen.
+- Ask side questions via /btw: while in a conversation, type ‘/btw’ in the input and select the ‘btw’ option in the menu to write a message to an ephemeral, single-response agent that has the context of your current conversation.
+- Simple conversation search functionality: cmd/ctrl+F to search for visible text in the conversation view.
+- Support for PDF attachments to messages to Gemini models: drag and drop PDFs from your filesystem or add PDFs using the media option in the Add Context menu button in the input box.
+- Breadcrumbs in file viewer pane header: quality-of-life UI to more easily see and navigate directories in your repo.
+- Nested subagents in the overview pane: see all nested subagents belonging to the main conversation instead of only the subagents that are one level deep.
+- Minor improvements to Projects UX: you can now specify a project name during the creation flow and sort conversations in the left sidebar by worktree.
+
+Fixes (4)
+
+- Improved LaTeX support: the agent has a better understanding and awareness of its ability to output LaTeX-rendered math text.
+- Improved MCP server stability: increased resilience to unresponsive MCP servers and improved browser agent self-troubleshooting abilities when using the Chrome DevTools MCP server.
+- MCP server schema compatibility: the mcp\_config.json schema now accepts url in addition to serverUrl as a field.
+- New entries in the sensitive paths list: .vscode and .cache are now recognized as sensitive paths that require explicit user confirmation before the agent can access them.
+
+Patches (0)
+
+2.0.11
+
+June 3, 2026
+
+### Antivirus and Open IDE fixes
+
+Startup and Open IDE button fixes
+
+Improvements (0)
+
+Fixes (2)
+
+- Fixed an issue that occurs when certain antivirus products are installed that caused a dark blank screen on app startup.
+- Fixed some bugs related to the Open IDE button.
+
+Patches (0)
+
+2.0.10
+
+May 28, 2026
+
+### AGY 2.0 Bug fixes
+
+AGY 2.0 Bug fixes
+
+Improvements (1)
+
+- Various reliability and usability improvements
+
+Fixes (1)
+
+- G1 credit bug fix
+
+Patches (0)
+
+2.0.6
+
+May 22, 2026
+
+### Antigravity IDE integration
+
+Added integration with Antigravity IDE.
+
+Improvements (2)
+
+- Add an install IDE button if Antigravity IDE is not installed.
+- Add an open IDE button if Antigravity IDE is installed which allows you to open the current project in Antigravity IDE.
+
+Fixes (0)
+
+Patches (0)
+
+2.0.1
+
+May 19, 2026
+
+### AGY 2.0 Bug Fixes
+
+Antigravity 2.0 Launch bug fixes.
+
+Improvements (0)
+
+Fixes (3)
+
+- Fixed project migration issues for projects with CJK characters in their titles.
+- Fixed an issue that caused duplicate projects to be created when importing from Antigravity 1.0.
+- Resolved an issue where Google One credits were not being applied or utilized.
+
+Patches (0)
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/docs-cli-commands-agents.md
+++ b/docs/docs-cli-commands-agents.md
@@ -1,0 +1,220 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Agents (/agents)
+
+# Agents Command (/agents) [link](https://antigravity.google/\#agents-command-agents)
+
+Browse, select, and switch between custom agents, or monitor active and completed background subagents directly inside an interactive TUI panel.
+
+## Before you begin [link](https://antigravity.google/\#before-you-begin)
+
+- [Install Antigravity CLI](https://antigravity.google/docs/cli/install)
+- Understand the [Asynchronous execution model](https://antigravity.google/docs/cli/subagents)
+
+## Overview [link](https://antigravity.google/\#overview)
+
+The `/agents` command opens the interactive **Agent Manager Panel**. This interface serves two distinct purposes:
+
+1. **Custom Agent Selection & Discovery**: Choose between the default agent and custom workflow-specific agents, or discover where to define new agents locally and globally.
+2. **Subagent Monitoring & Control**: Track, inspect, or terminate background subagents running concurrently during your active session.
+
+To open the panel inside the TUI, type `/agents` and press `Enter`:
+
+bash
+
+content\_copy
+
+```
+            /agents
+
+```
+
+![Interactive Agents Panel](https://antigravity.google/assets/image/docs/cli/agents-panel.png)
+
+\-\-\-
+
+## Custom Agent Selection & Discovery [link](https://antigravity.google/\#custom-agent-selection-discovery)
+
+Antigravity CLI supports loading custom agent definitions with specialized system instructions and tool permissions. The **Available Agents** section lists all agents currently available to your session.
+
+### 1\. Switching between agents [link](https://antigravity.google/\#1-switching-between-agents)
+
+- **Select**: Use `↑`/`↓` to highlight an agent (`Default agent` or a custom agent) under **Available Agents**, then press `Enter`.
+- **Status Indicator**: A green circle (`●`) indicates the active or prepared agent.
+- **Apply & Exit**: Press `Esc` to close the panel and apply your selection.
+
+\> **Note:** If you are currently inside an active conversation, switching custom agents automatically forks your current session (`[ Switch will fork the current conversation on exit ]`) so you do not lose context. If you start from a fresh session, the switch applies directly (`[ Switch will create a new conversation on exit ]`).
+
+### 2\. Creating custom agents [link](https://antigravity.google/\#2-creating-custom-agents)
+
+The header of the `/agents` panel displays exact template locations for creating new custom agents:
+
+text
+
+content\_copy
+
+```
+            Create New Agents
+  Workspace: {workspace}/.agents/agents/{agent_name}/agent.md
+  Global: ~/.gemini/config/agents/{agent_name}/agent.md
+
+```
+
+To create a custom agent that is available across all your workspaces and projects, place it under your global customization directory (`~/.gemini/config/agents/`). Create a directory matching your agent name and add an `agent.md` file with YAML frontmatter:
+
+bash
+
+content\_copy
+
+```
+            mkdir -p ~/.gemini/config/agents/code-reviewer
+cat << 'EOF' > ~/.gemini/config/agents/code-reviewer/agent.md
+---
+name: code-reviewer
+description: Rigorous code review specialist focusing on edge cases and security.
+---
+You are an expert code reviewer. Analyze diffs carefully and verify edge cases.
+EOF
+
+```
+
+When you reopen `/agents`, the CLI automatically discovers `code-reviewer` and lists it under **Available Agents**. If you need an agent scoped strictly to a single project repository, place it inside that workspace's `.agents/agents/` directory (for example, `/home/user/projects/my-app/.agents/agents/code-reviewer/agent.md`). You can also package and distribute custom agents inside [Plugins](https://antigravity.google/docs/cli/plugins).
+
+\-\-\-
+
+## Subagent Monitoring & Control [link](https://antigravity.google/\#subagent-monitoring-control)
+
+When your primary agent delegates tasks (such as running tests or querying large codebases), the spawned threads appear in the `/agents` panel under **Subagents**, grouped by their triggering prompt.
+
+### 1\. Inspecting subagent progress [link](https://antigravity.google/\#1-inspecting-subagent-progress)
+
+- **Group Toggling**: Press `Enter` on a subagent group header (`▸ Subagents (1 running, 2 done)`) to expand or collapse (`▾`) that group.
+- **Status Indicators**: Each subagent row displays a live lifecycle state:
+- `running`: Actively executing tools or generating reasoning steps.
+- `done`: Successfully completed its assigned background task.
+- `error`: Encountered a terminal failure during execution.
+- `killed`: Terminated manually by the user or parent process.
+- **Detail View**: Highlight a specific subagent row and press `Enter` to open the full-screen **Subagent Detail View**. This view displays the subagent's complete internal thoughts, tool calls, and execution stdout. Press `Esc` to return to the list.
+
+### 2\. Terminating active subagents [link](https://antigravity.google/\#2-terminating-active-subagents)
+
+If a background subagent loops or runs longer than needed, you can kill it immediately without leaving your session:
+
+1. Open `/agents` and highlight the running subagent row.
+2. Press `k` to kill the active subagent and all its child threads.
+
+### 3\. Inline tool approvals [link](https://antigravity.google/\#3-inline-tool-approvals)
+
+If a subagent attempts a protected operation (such as modifying a file or running a shell command in a sandboxed environment), the authorization prompt displays inline in the `/agents` panel. You can press `a` to approve or `d` to deny directly from the list.
+
+\-\-\-
+
+## Panel Keybindings Reference [link](https://antigravity.google/\#panel-keybindings-reference)
+
+When focused inside the `/agents` panel, the following keyboard shortcuts apply:
+
+| Key | Action | Behavior |
+| --- | --- | --- |
+| **`↑` / `↓`** | Navigate | Move the cursor between headers, subagents, and available agents. |
+| **`Enter`** | Select / Toggle | Expand/collapse groups, open Subagent Detail View, or select a custom agent. |
+| **`k`** | Kill Active Subagent | Instantly cancel (`CancelSubagent`) the highlighted running subagent. |
+| **`Esc`** | Go Back | Exit the panel, return to the prompt box, and apply any prepared agent switch. |
+
+\-\-\-
+
+## Common mistakes [link](https://antigravity.google/\#common-mistakes)
+
+| Mistake | Why it fails | Fix |
+| --- | --- | --- |
+| Expecting custom agent switches to modify the existing turn history | Switching agents inside an active thread forks the conversation to preserve historical integrity | Continue your workflow in the newly forked session with the new agent's capabilities |
+| Putting custom agent markdown files directly inside `~/.gemini/config/agents/` or `.agents/` | The CLI scanner expects agents to live inside dedicated subdirectories under `~/.gemini/config/agents/<name>/` or `.agents/agents/<name>/` | Move your agent definition to `~/.gemini/config/agents/<name>/agent.md` |
+| Using `k` on completed subagents | `KeyKillSubagent` only targets active (`running`) subagent processes | Use `Enter` to inspect completed or failed subagent logs instead |
+
+\-\-\-
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+- [Background tasks & subagents](https://antigravity.google/docs/cli/subagents): Learn more about the multi-threaded asynchronous execution architecture.
+- [Plugins & Skills](https://antigravity.google/docs/cli/plugins): Discover how to bundle custom agents, skills, and MCP configs into shareable plugins.
+- [Permissions & Sandbox](https://antigravity.google/docs/cli/sandbox): Configure security guardrails and approval rules for background subagents.
+
+[Terminal Title Customization](https://antigravity.google/docs/cli/title)
+
+[Code Search Command (/codesearch)](https://antigravity.google/docs/cli/commands/codesearch)
+
+On this Page
+
+- Agents Command (/agents)
+
+- Before you begin
+
+- Overview
+
+- Custom Agent Selection & Discovery
+
+- Subagent Monitoring & Control
+
+- Panel Keybindings Reference
+
+- Common mistakes
+
+- Next steps

--- a/docs/docs-cli-commands-credits.md
+++ b/docs/docs-cli-commands-credits.md
@@ -1,0 +1,172 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings chevron\_right
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands expand\_more
+
+[Agents (/agents)](https://antigravity.google/docs/cli/commands/agents)
+
+[Code Search (/codesearch)](https://antigravity.google/docs/cli/commands/codesearch)
+
+[AI Credits (/credits)](https://antigravity.google/docs/cli/commands/credits)
+
+[Diff (/diff)](https://antigravity.google/docs/cli/commands/diff)
+
+[Permissions (/permissions)](https://antigravity.google/docs/cli/commands/permissions)
+
+[Resume (/resume)](https://antigravity.google/docs/cli/commands/resume)
+
+[Status Line (/statusline)](https://antigravity.google/docs/cli/commands/statusline)
+
+[Window Title (/title)](https://antigravity.google/docs/cli/commands/title)
+
+[Model Quotas (/usage, /quota)](https://antigravity.google/docs/cli/commands/usage)
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- AI Credits (/credits)
+
+# AI Credits Command (/credits) [link](https://antigravity.google/\#ai-credits-command-credits)
+
+View and manage your AI Premium credits interactively.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+The `/credits` command opens a dedicated panel in the TUI that displays your current AI Premium credit balance, consumption history, and links to manage your subscription or purchase additional credits.
+
+For details on how credits are tracked, low credit alerts, and settings configuration, see the conceptual **[AI Credits Guide](https://antigravity.google/docs/cli/credits)**.
+
+## Using the Credits Command [link](https://antigravity.google/\#using-the-credits-command)
+
+To view your credit status:
+
+1. Type `/credits` in the prompt box.
+2. Press `Enter`.
+
+text
+
+content\_copy
+
+```
+            /credits
+
+```
+
+The credits panel will display:
+
+- **Active Balance**: Your remaining AI Premium credits.
+- **Usage Summary**: A breakdown of credits consumed in the current billing cycle.
+- **Quick Links**: Actions to buy more credits or upgrade your plan (which will open the relevant web portals).
+
+Press `Esc` to close the panel and return to the main prompt.
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+- **[AI Credits Guide](https://antigravity.google/docs/cli/credits)**: Learn about credit consumption, alerts, and settings.
+- **[Model Quotas Command](https://antigravity.google/docs/cli/commands/usage)**: Monitor your model-specific API quotas.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: See all available slash commands.
+
+[Code Search Command (/codesearch)](https://antigravity.google/docs/cli/commands/codesearch)
+
+[Diff Command (/diff)](https://antigravity.google/docs/cli/commands/diff)
+
+On this Page
+
+- AI Credits Command (/credits)
+
+- Overview
+
+- Using the Credits Command
+
+- Next steps

--- a/docs/docs-cli-commands-diff.md
+++ b/docs/docs-cli-commands-diff.md
@@ -1,0 +1,278 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings chevron\_right
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands expand\_more
+
+[Agents (/agents)](https://antigravity.google/docs/cli/commands/agents)
+
+[Code Search (/codesearch)](https://antigravity.google/docs/cli/commands/codesearch)
+
+[AI Credits (/credits)](https://antigravity.google/docs/cli/commands/credits)
+
+[Diff (/diff)](https://antigravity.google/docs/cli/commands/diff)
+
+[Permissions (/permissions)](https://antigravity.google/docs/cli/commands/permissions)
+
+[Resume (/resume)](https://antigravity.google/docs/cli/commands/resume)
+
+[Status Line (/statusline)](https://antigravity.google/docs/cli/commands/statusline)
+
+[Window Title (/title)](https://antigravity.google/docs/cli/commands/title)
+
+[Model Quotas (/usage, /quota)](https://antigravity.google/docs/cli/commands/usage)
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Diff (/diff)
+
+# Diff Command (/diff) [link](https://antigravity.google/\#diff-command-diff)
+
+View and review workspace changes, commit history, and agent turn diffs interactively within the TUI.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+The `/diff` command opens the **Interactive Diff Viewer**, a full-screen panel that allows you to inspect changes in your workspace and conversation history. It supports three distinct modes (VCS, Turn, and Commit) and provides an interactive review workflow where you can add line-by-line comments to steer the agent's next steps.
+
+## Interactive Diff Viewer Panels [link](https://antigravity.google/\#interactive-diff-viewer-panels)
+
+To open the Diff Viewer:
+
+1. Type `/diff` in the prompt box.
+2. Press `Enter`.
+
+text
+
+content\_copy
+
+```
+            /diff
+
+```
+
+### Navigation and Controls [link](https://antigravity.google/\#navigation-and-controls)
+
+The Diff Viewer operates in three modes, which you can cycle through using **`Tab`** (or **`Right`** / **`Left`** arrow keys):
+
+- **VCS Mode**: Shows a list of all modified and untracked files in your active workspace.
+- Supports Git, Mercurial (Hg), and Jujutsu (JJ) automatically.
+- Use `↑`/`↓` to navigate the file list, and `Enter` to open the detail view.
+- **Turn Mode**: Shows the changes introduced by the agent in each turn of the current conversation.
+- Useful for reviewing the agent's work step-by-step.
+- Use `↑`/`↓` to navigate, and `Enter` to view details.
+- **Commit Mode**: Renders an interactive commit graph/tree of your repository.
+- Use `↑`/`↓` to navigate the commit chain.
+- Use `←`/`→` to navigate to adjacent branches in the graph.
+- Press `Enter` to load the diff for the selected commit.
+
+\-\-\-
+
+## Step-by-Step Walkthrough [link](https://antigravity.google/\#step-by-step-walkthrough)
+
+Here is how to use the Diff Viewer to review changes, add comments, and steer the agent.
+
+### 1\. Reviewing Workspace Changes (VCS Mode) [link](https://antigravity.google/\#1-reviewing-workspace-changes-vcs-mode)
+
+When you run `/diff`, it opens in **VCS Mode** by default (if you have uncommitted changes). You will see a list of modified and untracked files:
+
+![VCS Diff List](https://antigravity.google/assets/image/docs/cli/diff-vcs-list.png)
+
+Press **`Enter`** on a file to open its **Detail View**. This shows the unified diff.
+
+- Use `↑`/`↓` (arrow keys) to scroll the diff.
+- Use `j`/`k` (or `←`/`→`) to quickly swap between files without returning to the list.
+- Use `n`/`N` to jump to the next/previous diff hunk.
+
+![Detail View](https://antigravity.google/assets/image/docs/cli/diff-detail.png)
+
+### 2\. Adding Comments and Steering the Agent [link](https://antigravity.google/\#2-adding-comments-and-steering-the-agent)
+
+While in the Detail View, you can review the code and write feedback directly onto specific lines.
+
+**Step 1: Locate the line** Scroll to the line you want to comment on.
+
+**Step 2: Open the comment input** Press **`c`**. The **Comment Input** overlay opens at the bottom:
+
+![Comment Input](https://antigravity.google/assets/image/docs/cli/diff-comment.png)
+
+**Step 3: Write your feedback** Type your feedback and press `Enter` to save (or `Esc` to cancel).
+
+**Step 4: Manage your comments** Saved comments are marked in the diff. You can delete a comment by highlighting the line and pressing **`d`**.
+
+**Step 5: Exit and submit** Press **`Esc`** to return to the file list. Press **`Esc`** again to exit `/diff`. If you have unsaved comments, a confirmation screen appears:
+
+- Press **`Shift+Y`** to approve and exit. Your comments are formatted and sent to the agent as your next prompt, allowing you to steer its next turn.
+- Press **`Shift+N`** to reject and exit, discarding the comments.
+
+### 3\. Reviewing Turn History (Turn Mode) [link](https://antigravity.google/\#3-reviewing-turn-history-turn-mode)
+
+Press **`Tab`** to switch to **Turn Mode**. This groups changes by the conversation turn in which they were introduced, allowing you to see exactly what the agent did in previous steps:
+
+![Turn Diff List](https://antigravity.google/assets/image/docs/cli/diff-turn-list.png)
+
+### 4\. Navigating the Commit Tree (Commit Mode) [link](https://antigravity.google/\#4-navigating-the-commit-tree-commit-mode)
+
+Press **`Tab`** again to switch to **Commit Mode**. This renders the repository's commit history as an interactive graph. You can navigate up and down the chain, or hop between branches using `←`/`→`:
+
+![Commit List](https://antigravity.google/assets/image/docs/cli/diff-commit-list.png)
+
+Highlight any commit and press **`Enter`** to load and review its diff:
+
+![Commit Detail](https://antigravity.google/assets/image/docs/cli/diff-commit-detail.png)
+
+\-\-\-
+
+## Keyboard Shortcuts Reference [link](https://antigravity.google/\#keyboard-shortcuts-reference)
+
+### File List View (VCS & Turn Modes) [link](https://antigravity.google/\#file-list-view-vcs-turn-modes)
+
+| Key | Action |
+| --- | --- |
+| **`Tab`** / **`→`** / **`←`** | Cycle modes (VCS → Turn → Commit) |
+| **`↑`** / **`↓`** (or **`j`** / **`k`**) | Navigate file list |
+| **`Enter`** | Open selected file's Detail View |
+| **`Esc`** | Exit Diff Viewer |
+
+### File Detail View [link](https://antigravity.google/\#file-detail-view)
+
+| Key | Action |
+| --- | --- |
+| **`↑`** / **`↓`** | Scroll diff content |
+| **`PgUp`** / **`PgDn`** | Scroll diff by page |
+| **`j`** / **`k`** (or **`→`** / **`←`**) | Switch to next / previous file |
+| **`n`** / **`N`** (or **`shift+n`**) | Jump to next / previous diff hunk |
+| **`c`** | Add/edit comment on the current line |
+| **`d`** | Delete comment on the current line |
+| **`Esc`** | Return to File List View |
+
+### Commit Tree View (Commit Mode) [link](https://antigravity.google/\#commit-tree-view-commit-mode)
+
+| Key | Action |
+| --- | --- |
+| **`↑`** / **`↓`** | Navigate commit history |
+| **`←`** / **`→`** | Navigate to adjacent branches in the graph |
+| **`Enter`** | Load diff for the selected commit |
+| **`Esc`** | Exit Diff Viewer |
+
+### Exit Confirmation Screen [link](https://antigravity.google/\#exit-confirmation-screen)
+
+| Key | Action |
+| --- | --- |
+| **`Shift+Y`** | Exit and send comments to the agent |
+| **`Shift+N`** | Exit and discard comments |
+| **`Esc`** | Return to File List View |
+
+## See also [link](https://antigravity.google/\#see-also)
+
+- **[Settings & Keybindings](https://antigravity.google/docs/cli/settings)**: Customize your TUI theme, alt-screen preferences, and keybindings.
+- **[Conversations](https://antigravity.google/docs/cli/conversations)**: Learn how to manage, fork, and rewind conversation threads.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: Quick reference for all slash commands and default shortcuts.
+
+[AI Credits Command (/credits)](https://antigravity.google/docs/cli/commands/credits)
+
+[Permissions Command (/permissions)](https://antigravity.google/docs/cli/commands/permissions)
+
+On this Page
+
+- Diff Command (/diff)
+
+- Overview
+
+- Interactive Diff Viewer Panels
+
+- Step-by-Step Walkthrough
+
+- Keyboard Shortcuts Reference
+
+- See also

--- a/docs/docs-cli-commands-permissions.md
+++ b/docs/docs-cli-commands-permissions.md
@@ -1,0 +1,186 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Permissions (/permissions)
+
+# Permissions Command (/permissions) [link](https://antigravity.google/\#permissions-command-permissions)
+
+Manage your fine-grained agent permission rules interactively within the TUI.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+Antigravity CLI uses a fine-grained permissions engine to secure your workstation. While you can configure these rules manually in your settings file, the `/permissions` command opens an interactive **Permissions Manager** TUI panel to view, add, edit, and delete rules live.
+
+For details on how the permission engine works, supported actions, and manual configuration, see the conceptual **[Permissions Guide](https://antigravity.google/docs/cli/permissions)**.
+
+## Managing permissions interactively [link](https://antigravity.google/\#managing-permissions-interactively)
+
+To open the Permissions Manager:
+
+1. Type `/permissions` in the prompt box.
+2. Press `Enter`.
+
+text
+
+content\_copy
+
+```
+            /permissions
+
+```
+
+### Navigation and controls [link](https://antigravity.google/\#navigation-and-controls)
+
+The Permissions Manager operates in three panels:
+
+1. **Scope Picker**: Select the configuration scope you want to edit:
+
+- **Project**: Rules applying only to the active project (disabled if no project is open).
+- **Shared**: Rules shared across all Antigravity products.
+- **Global**: Global rules applying to all your sessions.
+
+Use `↑`/`↓` (or `j`/`k`) to navigate, `Enter` to select, and `Esc` to exit.
+
+1. **Rule Viewer**: View the rules configured for the selected scope.
+
+- Switch between **allowlist**, **denylist**, and **asklist** tabs using `←`/`→` (or `Tab`).
+- Scroll through the rules using `↑`/`↓` (or `j`/`k`).
+- Press `a` to add a new rule.
+- Press `e` (or `Ctrl+G`) to edit the highlighted rule.
+- Press `d` (or `Backspace`) to delete the highlighted rule.
+- Press `Esc` to return to the Scope Picker.
+
+1. **Add/Edit Rule**: Type or edit a rule in the input field.
+
+- Rules must follow the `action(target)` format (e.g., `command(git)`).
+- Press `Enter` to validate and save the rule.
+- Press `Esc` to cancel.
+
+\-\-\-
+
+## Step-by-step walkthrough [link](https://antigravity.google/\#step-by-step-walkthrough)
+
+Here is how to view, add, edit, and delete rules live in the TUI.
+
+### 1\. Selecting a scope and viewing rules [link](https://antigravity.google/\#1-selecting-a-scope-and-viewing-rules)
+
+When you run `/permissions`, you first see the **Scope Picker**. Select **Global** to manage your global rules:
+
+![Selecting Global Scope](https://antigravity.google/assets/image/docs/cli/permissions-scope.png)
+
+Press `Enter` to open the **Rule Viewer** for the selected scope. You can use `←`/`→` to switch between the **allow**, **deny**, and **ask** tabs:
+
+![Global Rule Viewer](https://antigravity.google/assets/image/docs/cli/permissions-viewer.png)
+
+### 2\. Adding a permission rule [link](https://antigravity.google/\#2-adding-a-permission-rule)
+
+To allow the agent to run `git` commands automatically without prompting:
+
+1. In the Rule Viewer, press `a`. The **Add Rule** panel opens at the bottom:
+
+![Add Rule Panel](https://antigravity.google/assets/image/docs/cli/permissions-add.png)
+
+1. Type `command(git)` in the input field:
+
+![Typing the Rule](https://antigravity.google/assets/image/docs/cli/permissions-add-typed.png)
+
+1. Press `Enter`. The rule is validated and saved. You are returned to the Rule Viewer, and `command(git)` now appears in your allowlist:
+
+![Rule Saved Successfully](https://antigravity.google/assets/image/docs/cli/permissions-viewer-with-rule.png)
+
+### 3\. Editing a permission rule [link](https://antigravity.google/\#3-editing-a-permission-rule)
+
+If you want to restrict the agent so it can only run `git diff` automatically, you can edit the rule:
+
+1. In the Rule Viewer, use `↑`/`↓` to highlight `command(git)`.
+2. Press `e` (or `Ctrl+G`). The input panel opens, prefilled with `command(git)`.
+3. Modify the text to `command(git diff)`.
+4. Press `Enter` to save. The old rule is replaced by the new one.
+
+### 4\. Deleting a permission rule [link](https://antigravity.google/\#4-deleting-a-permission-rule)
+
+To remove a rule and revert to prompting for those actions:
+
+1. In the Rule Viewer, highlight the rule you want to delete (e.g., `command(git diff)`).
+2. Press `d` (or `Backspace`).
+3. The rule is immediately removed from the list.
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+- **[Permissions Guide](https://antigravity.google/docs/cli/permissions)**: Learn about the security model, action types, and wildcard matching.
+- **[Sandbox & Security](https://antigravity.google/docs/cli/sandbox)**: Configure the native OS container for running commands.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: See all available slash commands and keybindings.
+
+[Diff Command (/diff)](https://antigravity.google/docs/cli/commands/diff)
+
+[Resume Command (/resume)](https://antigravity.google/docs/cli/commands/resume)
+
+On this Page
+
+- Permissions Command (/permissions)
+
+- Overview
+
+- Managing permissions interactively
+
+- Step-by-step walkthrough
+
+- Next steps

--- a/docs/docs-cli-commands-resume.md
+++ b/docs/docs-cli-commands-resume.md
@@ -1,0 +1,222 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Resume (/resume)
+
+# Resume Command (/resume) [link](https://antigravity.google/\#resume-command-resume)
+
+Browse, search, and resume past conversation threads, or recover your last session instantly from the command line.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+Antigravity CLI allows you to maintain multiple ongoing development threads. The `/resume` command opens an interactive **Session Picker** TUI panel to browse and load your history. You can also resume sessions directly from your host terminal using command-line flags.
+
+\-\-\-
+
+## Interactive Session Picker [link](https://antigravity.google/\#interactive-session-picker)
+
+To open the Session Picker inside the TUI:
+
+1. Type `/resume` (or aliases `/switch`, `/conversation`) in the prompt box.
+2. Press `Enter`.
+
+text
+
+content\_copy
+
+```
+            /resume
+
+```
+
+### 1\. Navigating and Searching Conversations [link](https://antigravity.google/\#1-navigating-and-searching-conversations)
+
+The Session Picker displays a list of past conversations sorted by recency (newest first).
+
+- **Search**: Start typing to instantly filter conversations by their title, preview text, or unique ID.
+- **Navigate**: Use `↑`/`↓` to scroll through the filtered list.
+- **Page**: Use `←`/`→` to page backward and forward through older history blocks.
+- **Select**: Highlight your target session and press `Enter` to load it.
+- **Exit**: Press `Esc` to close the picker and return to the active prompt.
+
+![Navigating Conversations](https://antigravity.google/assets/image/docs/cli/resume-navigate.png)
+
+### 2\. Renaming a Conversation [link](https://antigravity.google/\#2-renaming-a-conversation)
+
+To keep your history organized, you can rename conversations directly within the picker:
+
+1. Use `↑`/`↓` to highlight the conversation you want to rename.
+2. Press `F2`. An input field opens at the bottom of the panel, prefilled with the current title.
+3. Type the new name and press `Enter` to save, or `Esc` to cancel.
+
+![Renaming a Conversation](https://antigravity.google/assets/image/docs/cli/resume-rename.png)
+
+### 3\. Deleting a Conversation [link](https://antigravity.google/\#3-deleting-a-conversation)
+
+To clean up obsolete threads:
+
+1. Highlight the target conversation in the list.
+2. Press `Ctrl+Delete`. A confirmation prompt appears.
+3. Press `Enter` (or `y`) to confirm deletion, or `Esc` (or `n`) to cancel.
+
+![Deleting a Conversation](https://antigravity.google/assets/image/docs/cli/resume-delete.png)
+
+### 4\. Importing from Antigravity 2.0 [link](https://antigravity.google/\#4-importing-from-antigravity-20)
+
+You can import and resume active threads initiated in the Antigravity 2.0 desktop application:
+
+1. With the Session Picker open, press `Tab` to switch from the **CLI** tab to the **Antigravity** tab.
+2. Highlight the desktop conversation you wish to import.
+3. Press `Enter`. A confirmation prompt `[Import this? (y/n)]` appears.
+4. Press `Enter` (or `y`) to confirm. The CLI clones the history, context, and tool trajectories into your terminal session.
+
+![Importing from Antigravity 2.0](https://antigravity.google/assets/image/docs/cli/resume-antigravity.png)
+
+\-\-\-
+
+## Command-Line Shortcuts [link](https://antigravity.google/\#command-line-shortcuts)
+
+You can bypass the TUI picker and resume sessions directly when launching `agy` from your host shell.
+
+### Quick Resume Last Session (\`-c\` / \`--continue\`) [link](https://antigravity.google/\#quick-resume-last-session-c-continue)
+
+To instantly resume the single most recent conversation associated with your active workspace:
+
+bash
+
+content\_copy
+
+```
+            agy -c
+
+```
+
+_(Alternative: `agy --continue`)_
+
+### Resume Specific Session (\`--conversation\`) [link](https://antigravity.google/\#resume-specific-session-conversation)
+
+To load a specific conversation directly by its unique ID:
+
+bash
+
+content\_copy
+
+```
+            agy --conversation <conversation-id>
+
+```
+
+\-\-\-
+
+## Under the Hood: The Session Cache [link](https://antigravity.google/\#under-the-hood-the-session-cache)
+
+When you use the `-c` / `--continue` flag, the CLI resolves the target session using a local workspace-keyed cache.
+
+### The Cache File [link](https://antigravity.google/\#the-cache-file)
+
+- **Location**: `~/.gemini/antigravity-cli/cache/last_conversations.json`
+- **Format**: A JSON map associating absolute workspace directory paths with their most recently active conversation ID:
+
+content\_copy
+
+```
+                {
+        "/usr/local/google/home/username/Develop/my-project": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "/usr/local/google/home/username/Develop/another-repo": "f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+    }
+
+```
+
+### Resolution Workflow [link](https://antigravity.google/\#resolution-workflow)
+
+1. **Launch**: You run `agy -c` from `/path/to/workspace`.
+2. **Lookup**: The CLI reads `last_conversations.json` and looks up the key `/path/to/workspace`.
+3. **Verification**: If an ID is found, the CLI queries the backend to verify the conversation still exists.
+4. **Load**:
+
+- If verified, it loads the session.
+- If the conversation was deleted or the key is missing, it starts a fresh session for that workspace.
+
+\-\-\-
+
+## See also [link](https://antigravity.google/\#see-also)
+
+- **[Managing Conversations](https://antigravity.google/docs/cli/conversations)**: Learn about workspace scoping and branching with `/fork`.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: See all available slash commands and default keybindings.
+- **[Settings & Keybindings](https://antigravity.google/docs/cli/settings)**: Configure rendering modes and customize keyboard shortcuts.
+
+[Permissions Command (/permissions)](https://antigravity.google/docs/cli/commands/permissions)
+
+[Status Line Command (/statusline)](https://antigravity.google/docs/cli/commands/statusline)
+
+On this Page
+
+- Resume Command (/resume)
+
+- Overview
+
+- Interactive Session Picker
+
+- Command-Line Shortcuts
+
+- Under the Hood: The Session Cache
+
+- See also

--- a/docs/docs-cli-commands-statusline.md
+++ b/docs/docs-cli-commands-statusline.md
@@ -1,0 +1,168 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Status Line (/statusline)
+
+# Status Line Command (/statusline) [link](https://antigravity.google/\#status-line-command-statusline)
+
+Toggle the TUI status line or configure a custom rendering command.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+The `/statusline` command allows you to quickly enable or disable the status line at the bottom of your TUI, or configure a custom shell command to render it dynamically, without manually editing your settings file.
+
+For details on how to write custom status line scripts and the JSON state payload schema, see the conceptual **[Status Line Customization Guide](https://antigravity.google/docs/cli/statusline)**.
+
+## Usage [link](https://antigravity.google/\#usage)
+
+Run the `/statusline` command with the following arguments to control its behavior:
+
+### Toggle Status Line [link](https://antigravity.google/\#toggle-status-line)
+
+Type `/statusline` with no arguments to toggle the status line on and off:
+
+text
+
+content\_copy
+
+```
+            /statusline
+
+```
+
+### Enable or Disable Explicitly [link](https://antigravity.google/\#enable-or-disable-explicitly)
+
+You can explicitly enable or disable the status line:
+
+- **Enable**: `/statusline on` or `/statusline enable`
+- **Disable**: `/statusline off` or `/statusline disable`
+
+bash
+
+content\_copy
+
+```
+            /statusline off
+
+```
+
+### Configure a Custom Command [link](https://antigravity.google/\#configure-a-custom-command)
+
+To route the agent state JSON payload to a custom script and render its output in the status line, pass the command as an argument:
+
+bash
+
+content\_copy
+
+```
+            /statusline ~/.gemini/antigravity-cli/statusline.sh
+
+```
+
+This immediately updates your settings and starts running the script to render the status line.
+
+### Revert to Default [link](https://antigravity.google/\#revert-to-default)
+
+To delete your custom command configuration and revert to the built-in default status line:
+
+bash
+
+content\_copy
+
+```
+            /statusline delete
+
+```
+
+_(Note: `/statusline reset` is also supported)._
+
+### Show Help [link](https://antigravity.google/\#show-help)
+
+To view the quick command reference:
+
+bash
+
+content\_copy
+
+```
+            /statusline help
+
+```
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+- **[Status Line Guide](https://antigravity.google/docs/cli/statusline)**: Learn how to write custom scripts and handle the JSON payload.
+- **[Window Title Command](https://antigravity.google/docs/cli/commands/title)**: Configure dynamic terminal window titles.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: See all available slash commands.
+
+[Resume Command (/resume)](https://antigravity.google/docs/cli/commands/resume)
+
+[Window Title Command (/title)](https://antigravity.google/docs/cli/commands/title)
+
+On this Page
+
+- Status Line Command (/statusline)
+
+- Overview
+
+- Usage
+
+- Next steps

--- a/docs/docs-cli-commands-title.md
+++ b/docs/docs-cli-commands-title.md
@@ -1,0 +1,129 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Window Title (/title)
+
+# Window Title Command (/title) [link](https://antigravity.google/\#window-title-command-title)
+
+Configure dynamic terminal window titles interactively.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+The `/title` command allows you to toggle the terminal window title feature on and off, or set its state explicitly. When enabled, the terminal title bar dynamically updates to show the active model, workspace, and agent state.
+
+For details on how to write custom scripts to format the window title, see the conceptual **[Terminal Title Customization Guide](https://antigravity.google/docs/cli/title)**.
+
+## Interactive Toggling [link](https://antigravity.google/\#interactive-toggling)
+
+You can control the window title feature by running the `/title` command.
+
+To toggle the feature on and off:
+
+text
+
+content\_copy
+
+```
+            /title
+
+```
+
+To enable it explicitly:
+
+text
+
+content\_copy
+
+```
+            /title on
+
+```
+
+To disable it explicitly:
+
+text
+
+content\_copy
+
+```
+            /title off
+
+```
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+- **[Terminal Title Guide](https://antigravity.google/docs/cli/title)**: Learn how to write custom scripts to format the window title.
+- **[Status Line Command](https://antigravity.google/docs/cli/commands/statusline)**: Customize your TUI status line.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: See all available slash commands.
+
+[Status Line Command (/statusline)](https://antigravity.google/docs/cli/commands/statusline)
+
+[Model Quotas (/usage)](https://antigravity.google/docs/cli/commands/usage)
+
+On this Page
+
+- Window Title Command (/title)
+
+- Overview
+
+- Interactive Toggling
+
+- Next steps

--- a/docs/docs-cli-commands-usage.md
+++ b/docs/docs-cli-commands-usage.md
@@ -1,0 +1,125 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Commands
+>- Model Quotas (/usage, /quota)
+
+# Model Quotas (/usage) [link](https://antigravity.google/\#model-quotas-usage)
+
+View your active model quota usage and refresh your configuration.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+Antigravity CLI provides the `/usage` command (alias `/quota`) to help you monitor your resource consumption. When run, the command refreshes your model configuration and quota status from the backend and opens an interactive TUI panel.
+
+## Viewing your usage [link](https://antigravity.google/\#viewing-your-usage)
+
+To open the Model Quotas panel:
+
+1. Type `/usage` (or `/quota`) in the prompt box.
+2. Press `Enter`.
+
+text
+
+content\_copy
+
+```
+            /usage
+
+```
+
+![Quota & Credits TUI](https://antigravity.google/assets/image/docs/cli/usage-tui.png)
+
+### Interactive Panel Features [link](https://antigravity.google/\#interactive-panel-features)
+
+The panel displays:
+
+- **Model Quotas**: A breakdown of your usage limits and remaining requests/tokens for each supported model (e.g., Gemini 3.5 Flash, Gemini 3.1 Pro).
+- **Active Refresh**: The CLI automatically triggers a fresh check of your quotas on disk and from the backend service when you open this panel.
+
+### Navigation Controls [link](https://antigravity.google/\#navigation-controls)
+
+Use the following keyboard shortcuts to navigate the panel:
+
+| Key | Action |
+| --- | --- |
+| `↑` / `↓` (or `j` / `k`) | Scroll up or down by one line. |
+| `PgUp` / `PgDn` | Scroll up or down by one page. |
+| `g` / `G` | Jump to the top or bottom of the list. |
+| `Esc` (or `q`) | Close the panel and return to the prompt. |
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: See all available slash commands and keybindings.
+- **[Settings & Rendering](https://antigravity.google/docs/cli/settings)**: Configure your default models and credit usage preferences.
+
+[Window Title Command (/title)](https://antigravity.google/docs/cli/commands/title)
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+On this Page
+
+- Model Quotas (/usage)
+
+- Overview
+
+- Viewing your usage
+
+- Next steps

--- a/docs/docs-cli-conversations.md
+++ b/docs/docs-cli-conversations.md
@@ -1,0 +1,169 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings chevron\_right
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Conversations
+
+# Managing conversations [link](https://antigravity.google/\#managing-conversations)
+
+Resume prior development threads, scope active histories to local workspaces, and fork conversations to experiment with alternate architectures.
+
+## Workspace scoping [link](https://antigravity.google/\#workspace-scoping)
+
+To maintain context hygiene, Antigravity CLI scopes conversation histories directly to your current working directory. When you launch `agy` from a specific directory, the agent only displays and resume sessions associated with that specific local repository or subdirectory.
+
+This prevents context pollution, ensuring that the agent's semantic memory and token limits remain focused solely on the relevant codebase.
+
+## Resuming sessions [link](https://antigravity.google/\#resuming-sessions)
+
+You can return to a prior conversation at any time to continue an implementation, refine a solution, or recover from an interrupted session.
+
+Antigravity CLI supports both an interactive **Session Picker** TUI overlay and direct command-line flags (`agy -c` / `agy --continue`) to resume threads instantly based on your active workspace.
+
+For a complete walkthrough of the interactive picker, keyboard shortcuts, and details on how the directory-scoped session cache works, see the dedicated **[Resume Command Guide](https://antigravity.google/docs/cli/commands/resume)**.
+
+## Branching with \`/fork\` [link](https://antigravity.google/\#branching-with-fork)
+
+When engineering a complex feature, you may want to explore multiple design alternatives without losing your progress. The `/fork` command enables safe, parallel experimentation.
+
+text
+
+content\_copy
+
+```
+            /fork
+
+```
+
+_(Alias: `/branch`)_
+
+The `/fork` command clones your entire conversation history up to the current turn into a new, independent session.
+
+### Forking workflow [link](https://antigravity.google/\#forking-workflow)
+
+1. Type `/fork` inside the prompt panel and press `Enter`.
+2. The CLI allocates a new unique session ID and duplicates your existing workspace state and agent thread.
+3. Your active terminal switches immediately to the new branch.
+4. If the experiment fails, run `/resume` to restore your original, stable conversation branch.
+
+lightbulb
+
+**Branching Filesystems**: Forking clones the _conversation thread_, not your local git checkout. To fully isolate files during parallel forks, use git branches or stash local changes before testing contrasting approaches.
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Explore how the agent handles complex, asynchronous operations and parallel tasks:
+
+- **[Background Tasks & Subagents](https://antigravity.google/docs/cli/subagents)**: Monitor subagents and handle fast-path approvals.
+- **[Settings, Rendering & Keybindings](https://antigravity.google/docs/cli/settings)**: Configure rendering buffers and override JSON preferences.
+- **[Permissions & Sandbox](https://antigravity.google/docs/cli/sandbox)**: Manage security profiles and system command lists.
+
+[Reviewing Artifacts](https://antigravity.google/docs/cli/artifacts)
+
+[Choose an execution mode](https://antigravity.google/docs/cli/modes)
+
+On this Page
+
+- Managing conversations
+
+- Workspace scoping
+
+- Resuming sessions
+
+- Branching with \`/fork\`
+
+- Next steps

--- a/docs/docs-cli-credits.md
+++ b/docs/docs-cli-credits.md
@@ -1,0 +1,119 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- AI Credits
+
+# Managing AI Credits & Quotas [link](https://antigravity.google/\#managing-ai-credits-quotas)
+
+The Antigravity CLI integrates with your subscription to monitor and manage your AI Premium credits and usage quotas.
+
+For a detailed explanation of baseline quotas, how credits are consumed, and plan eligibility, please refer to the main **[Plans](https://antigravity.google/docs/plans)** page.
+
+## Quota Tracking [link](https://antigravity.google/\#quota-tracking)
+
+You can monitor your active quota and credit consumption directly inside the CLI:
+
+- **Statusline Indicator**: The right side of the CLI statusline displays your remaining credit count (e.g., `AI Credits: 42`).
+- **Low Quota Alert**: When your remaining AI credits drop below the warning threshold, the statusline indicator highlights to warn you that your limits are near.
+
+## Slash Commands & Managing Balance [link](https://antigravity.google/\#slash-commands-managing-balance)
+
+You can query your credits or buy additional quota directly from the CLI:
+
+- **Query Balance**: Run the **[AI Credits Command](https://antigravity.google/docs/cli/commands/credits)** to open the dedicated credits panel. This panel displays your detailed credit usage statistics.
+- **Managing Credits**: You can easily purchase AI credits or upgrade your subscription, which opens a panel containing direct pricing and subscription portal links.
+
+## Settings Configuration [link](https://antigravity.google/\#settings-configuration)
+
+To control when and how your AI credits are used, you can toggle credit settings in your `settings.json` file:
+
+json
+
+content\_copy
+
+```
+            {
+  "useG1Credits": true
+}
+
+```
+
+- **Use AI Credits Option**: Run `/config` or `/settings` to open the CLI settings panel. Set the **Use G1 Credits** field to **on** to allow the CLI to use your personal credits when plan quotas are exhausted, or set it to **off** to restrict fallback billing. (To learn more, see the **[Plans](https://antigravity.google/docs/plans#overages)** overages section).
+
+## See also [link](https://antigravity.google/\#see-also)
+
+- **[AI Credits Command](https://antigravity.google/docs/cli/commands/credits)**: View and manage your credits interactively in the TUI.
+- **[Model Quotas Command](https://antigravity.google/docs/cli/commands/usage)**: Monitor your model-specific API quotas.
+
+[Settings, Rendering & Keybindings](https://antigravity.google/docs/cli/settings)
+
+[MCP](https://antigravity.google/docs/mcp)
+
+On this Page
+
+- Managing AI Credits & Quotas
+
+- Quota Tracking
+
+- Slash Commands & Managing Balance
+
+- Settings Configuration
+
+- See also

--- a/docs/docs-cli-gcli-migration.md
+++ b/docs/docs-cli-gcli-migration.md
@@ -1,0 +1,240 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings chevron\_right
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Gemini Migration
+
+# Migrating from Gemini CLI [link](https://antigravity.google/\#migrating-from-gemini-cli)
+
+Convert your legacy configurations, import Gemini CLI extensions as native plugins, adapt custom skills paths, and reformat Model Context Protocol configurations.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+Antigravity CLI preserves backward compatibility with the core developer-experience constructs popularized by Gemini CLI. To ensure a seamless upgrade, the CLI offers automatic onboarding conversion alongside explicit CLI migration command sequences.
+
+## First-launch onboarding [link](https://antigravity.google/\#first-launch-onboarding)
+
+When you execute `agy` for the first time in an environment containing legacy configurations, the CLI automatically detects your existing profiles. An interactive checklist prompts you to choose which assets to migrate:
+
+1. **Auto-conversion**: Select the extensions and global configurations you wish to convert.
+2. **Keyring storage**: The CLI migrates your active session tokens securely into your operating system's native keyring storage.
+3. **Settings alignment**: Default visual parameters and rendering buffers map automatically to your new settings profile.
+
+info
+
+**Partial Parity**: While we preserve support for workspace skills, rules, and MCP servers, certain customized terminal themes or experimental visual overlays from Gemini CLI may not be supported.
+
+## Converting extensions to plugins [link](https://antigravity.google/\#converting-extensions-to-plugins)
+
+Since Gemini CLI launched, the industry has standardized on the term **plugins**. You can manually convert your legacy Gemini extensions to native Antigravity plugins by executing:
+
+bash
+
+content\_copy
+
+```
+            agy plugin import gemini
+
+```
+
+This utility searches your legacy local directories, parses your extension manifests, and converts files into native layout blocks.
+
+### Expected import output [link](https://antigravity.google/\#expected-import-output)
+
+text
+
+content\_copy
+
+```
+            [ok]   conductor-tools
+       - skills     : skipped (none detected)
+       - agents     : skipped (none detected)
+       ✔ commands   : 4 legacy commands converted to skills
+       - mcpServers : skipped (none detected)
+[ok]   google-workspace
+       ✔ skills     : 5 skills processed
+       - agents     : skipped (none detected)
+       ✔ commands   : 2 legacy commands converted to skills
+       ✔ mcpServers : 1 server definition migrated to mcp_config.json
+
+```
+
+## Context files and workspace rules [link](https://antigravity.google/\#context-files-and-workspace-rules)
+
+Both CLI platforms utilize identical workspace context rules. No modifications are needed to your existing rule documents:
+
+- **Workspace local context**: The agent continues to parse and enforce rule constraints defined inside your active directory's `GEMINI.md` and `AGENTS.md` files.
+- **Global developer context**: The agent automatically consults and enforces your global constraints located at `~/.gemini/GEMINI.md`.
+
+## Updated skills paths [link](https://antigravity.google/\#updated-skills-paths)
+
+While global shared skills remain in your user home directory, the target folder path for local workspace-specific skills has been updated.
+
+| Configuration | Gemini CLI | Antigravity CLI |
+| --- | --- | --- |
+| **Global shared path** | `~/.gemini/skills/` | `~/.gemini/antigravity-cli/skills/` |
+| **Workspace project path** | `.gemini/skills/` | `.agents/skills/` |
+
+warning
+
+**Action Required**: If your project contains custom workspace skills defined in `.gemini/skills/`, you must manually rename or relocate the folder to `.agents/skills/` for the Antigravity agent to recognize them as active slash commands.
+
+## MCP config formatting changes [link](https://antigravity.google/\#mcp-config-formatting-changes)
+
+Antigravity CLI separates Model Context Protocol servers into dedicated, lightweight JSON profiles instead of nesting them inside your primary preferences configuration.
+
+### Directory mapping [link](https://antigravity.google/\#directory-mapping)
+
+- **Legacy Gemini Config**: Servers were declared inline within `~/.gemini/settings.json`.
+- **Antigravity CLI Config**: Servers are defined inside a standalone `mcp_config.json` profile:
+- Global servers: `~/.gemini/config/mcp_config.json`
+- Workspace servers: `.agents/mcp_config.json`
+
+### Required schema updates [link](https://antigravity.google/\#required-schema-updates)
+
+When manually migrating remote websocket or SSE server definitions, update the URI key parameter to match the current standard:
+
+- **Legacy schema keys**: `url` or `httpUrl`
+- **Modern schema key**: `serverUrl`
+
+json
+
+content\_copy
+
+```
+            {
+  "mcpServers": {
+    "remote-indexer": {
+      "serverUrl": "https://mcp.internal.enterprise.com/sse",
+      "env": {
+        "AUTH_TOKEN": "secure_alpha_token"
+      }
+    }
+  }
+}
+
+```
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Begin configuring your new visual parameters and troubleshooting any setup anomalies:
+
+- **[Settings, Rendering & Keybindings](https://antigravity.google/docs/cli/settings)**: Customize keyboard hotkeys, themes, and screen buffers.
+- **[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)**: Learn how to resolve authentication lockouts or path issues.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: Access standard parameters lists and slash command mappings.
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Prompting & Interaction](https://antigravity.google/docs/cli/prompting)
+
+On this Page
+
+- Migrating from Gemini CLI
+
+- Overview
+
+- First-launch onboarding
+
+- Converting extensions to plugins
+
+- Context files and workspace rules
+
+- Updated skills paths
+
+- MCP config formatting changes
+
+- Next steps

--- a/docs/docs-cli-getting-started.md
+++ b/docs/docs-cli-getting-started.md
@@ -1,0 +1,161 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Getting Started
+
+# Getting Started with Antigravity CLI [link](https://antigravity.google/\#getting-started-with-antigravity-cli)
+
+Welcome to Antigravity CLI! This guide provides a direct, high-level developer roadmap to install the client, launch the Terminal User Interface (TUI), and begin collaborating with autonomous agents.
+
+## Roadmap checklist [link](https://antigravity.google/\#roadmap-checklist)
+
+Complete the following sequential steps to launch your first session:
+
+1. **Install the client (fast path)**
+
+Run the appropriate fast-path command for your operating system:
+
+**macOS / Linux**:
+
+content\_copy
+
+```
+                curl -fsSL https://antigravity.google/cli/install.sh | bash
+
+```
+
+**Windows (PowerShell)**:
+
+content\_copy
+
+```
+                irm https://antigravity.google/cli/install.ps1 | iex
+
+```
+
+**Windows (CMD)**:
+
+content\_copy
+
+```
+                curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+```
+
+By default, the installer registers the `agy` binary to your platform-specific directory:
+
+- **macOS / Linux**: `~/.local/bin/agy`
+- **Windows**: `C:\Users\<Username>\AppData\Local\agy\bin` (where `<Username>` represents your active Windows profile name).
+
+info
+
+**Advanced Setup**: For detailed enterprise credentials configuration, secure keyring auth permissions, proxy setups, or troubleshooting installation issues, consult the **[Installation & Auth Guide](https://antigravity.google/docs/cli/install)**.
+
+1. **Launch the TUI inside a project**
+
+Open a fresh terminal window, navigate to your target project codebase directory, and execute the launcher command:
+
+content\_copy
+
+```
+                agy
+
+```
+
+1. **Complete the first-launch setup**
+
+On your very first launch, the TUI walks you through a brief interactive setup:
+
+- **Color Scheme**: Select your preferred visual theme (Solarized, Dark, Solarized Light, or standard Terminal colors).
+- **Rendering Mode**: Choose Alt-Screen mode (alternate buffer with full-screen scrolling) or Inline mode (sequential stream integrated with your terminal's history).
+- **Workspace Trust**: Confirm that you trust the repository directory. Once confirmed, the agent indexes the files and stands ready.
+
+1. **Run your first agent task**
+
+Type the following instruction in the prompt box at the bottom of your TUI screen and press `Enter`:
+
+content\_copy
+
+```
+                Write a simple python script to fetch web page text
+
+```
+
+The agent reads the workspace, reasons about the task, and proposes a plan. For a detailed step-by-step tutorial on reviewing code and running test commands inside the TUI, follow the **[Tutorial Guide](https://antigravity.google/docs/cli/tutorial)**.
+
+## Related resources [link](https://antigravity.google/\#related-resources)
+
+Optimize your local environment configurations and master advanced collaboration tools:
+
+- **[Best Practices](https://antigravity.google/docs/cli/best-practices)**: Master verification loops, planning phases, rule files, and session checkpoints.
+- **[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)**: Resolve common path, keyring, or SSH forwarding errors.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: Dense reference sheets cataloging all slash commands, shortcuts, and JSON keys.
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+On this Page
+
+- Getting Started with Antigravity CLI
+
+- Roadmap checklist
+
+- Related resources

--- a/docs/docs-cli-install.md
+++ b/docs/docs-cli-install.md
@@ -1,0 +1,180 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Installation & Auth
+
+# Installation & auth [link](https://antigravity.google/\#installation-auth)
+
+Install Antigravity CLI, configure enterprise requirements, and establish secure authenticated sessions.
+
+## Installation [link](https://antigravity.google/\#installation-2)
+
+Antigravity CLI runs natively on macOS, Linux, and Windows. Use the platform-specific scripts below to install or upgrade the binary on your system.
+
+### macOS and Linux [link](https://antigravity.google/\#macos-and-linux)
+
+Execute the native installer script to download and install the executable to `~/.local/bin/agy`:
+
+bash
+
+content\_copy
+
+```
+            curl -fsSL https://antigravity.google/cli/install.sh | bash
+
+```
+
+### Windows [link](https://antigravity.google/\#windows)
+
+The installation script registers the `agy` binary to your local user directory: `C:\Users\<Username>\AppData\Local\agy\bin` (where `<Username>` represents your active Windows user profile).
+
+**PowerShell**: Open PowerShell and execute the following installation script:
+
+powershell
+
+content\_copy
+
+```
+            irm https://antigravity.google/cli/install.ps1 | iex
+
+```
+
+**CMD**: Open a standard Command Prompt and execute:
+
+cmd
+
+content\_copy
+
+```
+            curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+```
+
+### Installation flags [link](https://antigravity.google/\#installation-flags)
+
+When executing the installation scripts, you can append the following customization flags:
+
+- `--skip-aliases`: Bypasses shell profile alias purging (prevents the script from purging or updating legacy `agy` or `antigravity` shell aliases).
+- `--skip-path`: Bypasses shell profile `PATH` appending (prevents the script from modifying your shell profile's dynamic environment variables).
+
+## Authentication workflows [link](https://antigravity.google/\#authentication-workflows)
+
+Antigravity CLI uses secure credentials and token profiles to communicate with the shared agent harness.
+
+### Local silent keyring sign-in [link](https://antigravity.google/\#local-silent-keyring-sign-in)
+
+When launching `agy` on your local machine, the CLI attempts to access your operating system's native secure keyring (such as Apple Keychain, Linux Secret Service/dbus, or Windows Credential Manager). If a valid token profile is found, the CLI authenticates your session silently without opening a browser.
+
+If no saved session is found:
+
+1. The CLI automatically launches your local default web browser.
+2. Sign in using your approved account credentials.
+
+### Remote SSH OAuth flow [link](https://antigravity.google/\#remote-ssh-oauth-flow)
+
+When running over SSH, the CLI detects the remote connection environment. Because it cannot launch a local web browser, the CLI initiates a manual URL loop:
+
+1. Launch `agy` in your remote terminal session.
+2. The CLI detects the SSH environment and prints a unique, secure authorization URL.
+3. Copy this URL and paste it into a web browser on your local machine.
+4. Sign in with your approved credentials and complete the authentication.
+5. The browser displays a unique alphanumeric authorization code.
+6. Copy this code, return to your remote SSH terminal, and paste it into the prompt.
+
+## Managing your session [link](https://antigravity.google/\#managing-your-session)
+
+Terminating your session clears active credentials and local cache directories.
+
+### Logging out [link](https://antigravity.google/\#logging-out)
+
+To disconnect your account and purge saved authentication profiles from your operating system's keyring, run the following command in the CLI prompt box:
+
+text
+
+content\_copy
+
+```
+            /logout
+
+```
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Once you complete installation and authentication, start interacting with your local agent:
+
+- **[Tutorial](https://antigravity.google/docs/cli/tutorial)**: Create and run a basic Python project with an agent.
+- **[Prompting & Interaction](https://antigravity.google/docs/cli/prompting)**: Explore multiline text editing, interrupt commands, and terminal media pasting.
+- **[Permissions & Sandbox](https://antigravity.google/docs/cli/sandbox)**: Configure secure filesystem directories and command limits.
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+On this Page
+
+- Installation & auth
+
+- Installation
+
+- Authentication workflows
+
+- Managing your session
+
+- Next steps

--- a/docs/docs-cli-overview.md
+++ b/docs/docs-cli-overview.md
@@ -1,0 +1,158 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings chevron\_right
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Overview
+
+# Antigravity CLI Overview [link](https://antigravity.google/\#antigravity-cli-overview)
+
+The Antigravity CLI is the lightweight Terminal User Interface (TUI) surface of Antigravity. It brings the same core agentic capabilities as Antigravity 2.0 (such as multi-step reasoning, multi-file editing, tool calling, and conversation history) directly to your terminal.
+
+## Why Antigravity CLI? [link](https://antigravity.google/\#why-antigravity-cli)
+
+Antigravity CLI brings the reasoning, execution, and orchestration capabilities of our shared agent harness directly into your local shell. While Antigravity 2.0 offers a comprehensive visual editor interface, the CLI is custom-built for speed, lightweight operation, and seamless integration with terminal-first workflows.
+
+### Platform comparison [link](https://antigravity.google/\#platform-comparison)
+
+| Feature | Antigravity CLI | Antigravity 2.0 |
+| --- | --- | --- |
+| **Primary interface** | Keyboard-driven TUI | Visual desktop editor / IDE |
+| **Performance overhead** | Near-zero, extremely lightweight | Standard desktop IDE footprint |
+| **Workflow focus** | Fast local iterations, SSH, headless | Complete project management, visual workspace |
+| **Navigation** | Universal keyboard shortcuts | Mouse and multi-panel layout |
+| **Remote usability** | Native SSH, tmux, and terminal multiplexers | Local workspace or remote development containers |
+
+## Integration features [link](https://antigravity.google/\#integration-features)
+
+Antigravity CLI operates in tandem with Antigravity 2.0, sharing configurations and enabling frictionless transitions between interfaces:
+
+- **Shared agent harness**: Both environments run on the exact same agent core. Any enhancements to multi-step reasoning, tool usage, or code comprehension apply across both platforms.
+- **Shared settings sync**: Your core preferences, permissions, and security configurations synchronize automatically across both interfaces. Updating a permission rule or standard configuration in one platform immediately updates the other.
+- **Conversation export**: Seamlessly move active conversations between platforms. If a terminal session grows in complexity and requires visual orchestration, export the conversation to Antigravity 2.0 to continue with the visual editor interface.
+
+## Migrating from Gemini CLI [link](https://antigravity.google/\#migrating-from-gemini-cli)
+
+If you are transitioning from Gemini CLI, the onboarding process supports a one-time import to automatically migrate your existing Gemini CLI extensions, skills, and settings. To learn more, read [Migrating from Gemini CLI](https://antigravity.google/docs/cli/gcli-migration).
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Explore the guides below to set up your environment and begin working with autonomous agents:
+
+- **[Installation & Auth](https://antigravity.google/docs/cli/install)**: Set up the CLI, configure enterprise parameters, and complete silent authentication.
+- **[Getting Started](https://antigravity.google/docs/cli/getting-started)**: Explore the onboarding roadmap, first-launch setups, and core conceptual models.
+- **[Tutorial](https://antigravity.google/docs/cli/tutorial)**: Run your first multi-file generation task with an active agent.
+- **[Prompting & Interaction](https://antigravity.google/docs/cli/prompting)**: Master multiline composing, prompt editing, and pasting terminal media.
+- **[Reviewing Artifacts](https://antigravity.google/docs/cli/artifacts)**: Leverage transparency and review agent plans, diffs, and test runs.
+- **[AI Credits](https://antigravity.google/docs/cli/credits)**: Configure and monitor AI Premium credits fallback, pricing links, and settings.
+- **[Plugins & Skills](https://antigravity.google/docs/cli/plugins)**: Create your own custom skills slash commands, manage hooks, and configure MCP servers.
+- **[Best Practices](https://antigravity.google/docs/cli/best-practices)**: Master workflow pipelines, verification loops, and session course-corrections.
+
+[Screenshots](https://antigravity.google/docs/screenshots)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+On this Page
+
+- Antigravity CLI Overview
+
+- Why Antigravity CLI?
+
+- Integration features
+
+- Migrating from Gemini CLI
+
+- Next steps

--- a/docs/docs-cli-plugins.md
+++ b/docs/docs-cli-plugins.md
@@ -1,0 +1,310 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Customizations
+>- Plugins & Skills
+
+# Plugins & skills [link](https://antigravity.google/\#plugins-skills)
+
+Extend agent capabilities, install third-party extension bundles, package custom workflow skills, and interface with Model Context Protocol (MCP) servers.
+
+## The extensibility model [link](https://antigravity.google/\#the-extensibility-model)
+
+Antigravity CLI is designed for limitless customization. You can augment the shared agent harness by installing structured package modules called **Plugins** or creating localized markdown blueprints called **Skills**.
+
+These customizations allow agents to access specialized proprietary commands, invoke domain-specific subagents, and consult customized style constraints.
+
+## Antigravity plugins [link](https://antigravity.google/\#antigravity-plugins)
+
+Plugins are namespaced bundles that package custom skills, background subagents, linting rules, Model Context Protocol definitions, and event hooks into a single deployable asset.
+
+### Plugin filesystem structure [link](https://antigravity.google/\#plugin-filesystem-structure)
+
+When you install or import a plugin, the CLI stages the bundle files within your global configuration path:
+
+text
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/plugins/<plugin_name>/
+
+```
+
+A compliant plugin contains the following layout:
+
+text
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/plugins/<plugin_name>/
+├── plugin.json                 # Required package marker file
+├── mcp_config.json             # Optional Model Context Protocol servers
+├── hooks.json                  # Optional pre/post tool event hooks
+├── skills/                     # Optional specialized skills directory
+├── agents/                     # Optional subagent definition templates
+└── rules/                      # Optional custom codebase rules files
+
+```
+
+### The plugin manifest (plugin.json) [link](https://antigravity.google/\#the-plugin-manifest-pluginjson)
+
+The `plugin.json` file is a mandatory manifest located at the root of your plugin directory. It defines the plugin's identity and metadata.
+
+**Manifest example**
+
+json
+
+content\_copy
+
+```
+            {
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "my-plugin",
+  "description": "A brief description of what my plugin does."
+}
+
+```
+
+**Field reference**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | String | **Yes** | The unique, machine-readable name of the plugin. It must contain only alphanumeric characters, hyphens, and underscores (matches `^[a-zA-Z0-9-_]+$`). This name is used to reference the plugin in CLI commands. |
+| `description` | String | No | A brief human-readable description of the plugin's purpose, displayed in plugin listings. |
+
+**Automatic validation**
+
+To enable automatic autocomplete and validation in editors like VS Code or WebStorm, include the `$schema` key pointing to the official schema URL:
+
+json
+
+content\_copy
+
+```
+            "$schema": "https://antigravity.google/schemas/v1/plugin.json"
+
+```
+
+**Full JSON Schema**
+
+json
+
+content\_copy
+
+```
+            {
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "title": "Antigravity Plugin Manifest",
+  "description": "Schema for Antigravity CLI plugin manifest files (plugin.json)",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The unique, machine-readable name of the plugin. Must contain only alphanumeric characters, hyphens, and underscores.",
+      "pattern": "^[a-zA-Z0-9-_]+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "A brief human-readable description of the plugin's purpose and capabilities."
+    }
+  },
+  "required": [\
+    "name"\
+  ],
+  "additionalProperties": false
+}
+
+```
+
+### Managing plugins via CLI subcommands [link](https://antigravity.google/\#managing-plugins-via-cli-subcommands)
+
+The CLI exposes a `plugin` (or plural `plugins`) subcommand pipeline to manage your extensions:
+
+- **List installed plugins**: Show active packages and their loaded components.
+
+content\_copy
+
+```
+                agy plugin list
+
+```
+
+- **Install a local or remote plugin**: Stage a package directory into your local profile.
+
+content\_copy
+
+```
+                agy plugin install /path/to/local/plugin
+
+```
+
+- **Disable/Enable a plugin**: Suspend a plugin's tools without deleting its assets.
+
+content\_copy
+
+```
+                agy plugin disable <plugin_name>
+    agy plugin enable <plugin_name>
+
+```
+
+- **Uninstall a plugin**: Purge the package directory and clean up registries.
+
+content\_copy
+
+```
+                agy plugin uninstall <plugin_name>
+
+```
+
+## Agent skills [link](https://antigravity.google/\#agent-skills)
+
+Skills are declarative, human-readable markdown files that outline explicit instruction protocols, scripts, and target resources for specialized engineering tasks.
+
+Once registered, **Skills convert automatically into slash commands** inside the TUI, allowing you to invoke them manually (e.g., typing `/refactor-ui`).
+
+### Creating local workspace skills [link](https://antigravity.google/\#creating-local-workspace-skills)
+
+To deploy workspace-specific skills that stay with your git repository:
+
+1. Create a directory named `.agents/skills/` at your project root.
+2. Inside, draft a markdown file with a `.md` extension (such as `format-tests.md`).
+3. Define the skill's Frontmatter metadata (see the example below).
+4. Below the metadata, write explicit instructions for the agent. When you run `agy` in this directory, the skill is compiled, and `/format-tests` becomes available in the prompt box.
+
+**Frontmatter example:**
+
+yaml
+
+content\_copy
+
+```
+            ---
+name: format-tests
+description: Standardize and re-format Python unittest assertions
+---
+
+```
+
+### Sharing global skills [link](https://antigravity.google/\#sharing-global-skills)
+
+To share skills across all workspaces on your workstation, place the target markdown files inside your global configuration path:
+
+text
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/skills/
+
+```
+
+Any markdown skill in this directory is automatically imported as a global slash command whenever you launch `agy` in any directory.
+
+## Managing hooks [link](https://antigravity.google/\#managing-hooks)
+
+Hooks intercept agent actions right before or immediately after execution. They are useful for running automated pre-flight checks or post-generation formats (such as running `prettier` after writing files).
+
+Hooks are defined inside a plugin's `hooks.json` or configured inside your primary `settings.json` file. You can inspect all loaded and active hooks inside the TUI by typing:
+
+text
+
+content\_copy
+
+```
+            /hooks
+
+```
+
+## Model Context Protocol (MCP) [link](https://antigravity.google/\#model-context-protocol-mcp)
+
+Model Context Protocol is an open standard enabling foundation models to interface securely with local APIs, file parsers, and custom developer tools.
+
+For comprehensive documentation on configuring local and remote MCP servers in Antigravity CLI, accessing the interactive `/mcp` manager overlay, and understanding server schemas and authentication, see the dedicated [MCP Documentation](https://antigravity.google/docs/mcp).
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Learn how to migrate your existing configurations from Gemini CLI and troubleshoot connection anomalies:
+
+- **[Migration from Gemini CLI](https://antigravity.google/docs/cli/gcli-migration)**: Fast-track your legacy extensions and config conversions.
+- **[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)**: Resolve terminal hook errors, lockouts, or network failures.
+- **[Permissions & Sandbox](https://antigravity.google/docs/cli/sandbox)**: Configure security containment rings around your custom plugins and MCP servers.
+
+[MCP](https://antigravity.google/docs/mcp)
+
+[Permissions](https://antigravity.google/docs/cli/permissions)
+
+On this Page
+
+- Plugins & skills
+
+- The extensibility model
+
+- Antigravity plugins
+
+- Agent skills
+
+- Managing hooks
+
+- Model Context Protocol (MCP)
+
+- Next steps

--- a/docs/docs-cli-projects.md
+++ b/docs/docs-cli-projects.md
@@ -1,0 +1,137 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Projects
+
+# Projects [link](https://antigravity.google/\#projects)
+
+Manage projects and organize conversation sessions in the Antigravity CLI.
+
+## Launching sessions with projects [link](https://antigravity.google/\#launching-sessions-with-projects)
+
+### 1\. Default project execution [link](https://antigravity.google/\#1-default-project-execution)
+
+When starting the CLI without any project flags, all conversations in the session will be in the `default-cli-project`:
+
+bash
+
+content\_copy
+
+```
+            agy
+
+```
+
+### 2\. Opening a session in a specific project [link](https://antigravity.google/\#2-opening-a-session-in-a-specific-project)
+
+If you want to open a session attached to a specific existing project, pass the `--project` flag with the target project ID:
+
+bash
+
+content\_copy
+
+```
+            agy --project=<project_id>
+
+```
+
+### 3\. Creating a new project on startup [link](https://antigravity.google/\#3-creating-a-new-project-on-startup)
+
+If you want to create a brand new project and initialize your CLI session inside it, pass the `--new-project` flag:
+
+bash
+
+content\_copy
+
+```
+            agy --new-project
+
+```
+
+### 4\. Resuming an existing conversation [link](https://antigravity.google/\#4-resuming-an-existing-conversation)
+
+If you resume a conversation (whether on startup via `--conversation=<conv_id>` or during a session using `/resume`), the conversation's associated project will automatically be used.
+
+## Moving conversations between projects (\`/fork\`) [link](https://antigravity.google/\#moving-conversations-between-projects-fork)
+
+While interacting in an active session, you can copy and continue your current conversation to a different project using the `/fork` slash command:
+
+text
+
+content\_copy
+
+```
+            /fork <project_id>
+
+```
+
+When executed, the CLI forks your current conversation and associates the newly created conversation with `<project_id>`.
+
+[Choose an execution mode](https://antigravity.google/docs/cli/modes)
+
+[Background Tasks & Subagents](https://antigravity.google/docs/cli/subagents)
+
+On this Page
+
+- Projects
+
+- Launching sessions with projects
+
+- Moving conversations between projects (\`/fork\`)

--- a/docs/docs-cli-prompting.md
+++ b/docs/docs-cli-prompting.md
@@ -1,0 +1,144 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Prompting
+
+# Prompting & interaction [link](https://antigravity.google/\#prompting-interaction)
+
+Master primary interaction patterns, multiline composition workflows, session interruption controls, and terminal media pasting.
+
+## The prompt box [link](https://antigravity.google/\#the-prompt-box)
+
+Antigravity CLI features a sticky prompt panel positioned at the bottom of your terminal screen. This panel handles standard user entries, multiline scripts, and direct media pasting.
+
+text
+
+content\_copy
+
+```
+            ───────────────────────────────────────────────────────────────────────────
+> Describe your next engineering task here...
+───────────────────────────────────────────────────────────────────────────
+
+```
+
+### Submitting prompts [link](https://antigravity.google/\#submitting-prompts)
+
+To initiate an agent turn, type your instruction into the prompt panel and press `Enter`. The agent immediately analyzes your current directory workspace, reads required configurations, and begins formulating an execution plan.
+
+### Interrupting active sessions [link](https://antigravity.google/\#interrupting-active-sessions)
+
+If the agent initiates an undesired task or loops during command execution, press `Esc` to immediately halt the session.
+
+lightbulb
+
+**Universal Escape**: The `Esc` key acts as a global escape hatch. Pressing `Esc` instantly cancels any active agent turn, closes overlay panels, and returns focus to a clean prompt box.
+
+## Multiline composition [link](https://antigravity.google/\#multiline-composition)
+
+For complex directives, structured test scenarios, or multi-paragraph instructions, use our built-in multiline features.
+
+### Shorthand newline insertions [link](https://antigravity.google/\#shorthand-newline-insertions)
+
+- **Standard**: Press `Shift+Enter` or `ctrl+j` to insert a clean newline within your active prompt window without submitting.
+- **macOS Terminal Fallback**: If using Apple Terminal (which does not forward `Shift+Enter` by default), press `Option+Enter`. Ensure you check **Use Option as Meta key** in your Terminal Preferences profile.
+- **Universal Slash Escape**: Type a trailing backslash `\` at the end of your active line and press `Enter`. The CLI automatically removes the backslash and inserts a newline.
+
+### Editing prompts in \`$EDITOR\` [link](https://antigravity.google/\#editing-prompts-in-editor)
+
+To draft or edit extensive prompt structures in your primary development editor:
+
+1. Press `ctrl+g` inside the empty prompt panel.
+2. The CLI launches your system's default text editor (such as `vim`, `nano`, or `code`, configured via `/config` or your environment's `$EDITOR` variable).
+3. Draft your multi-line instruction inside the temporary editor buffer.
+4. Save and exit the editor. The CLI automatically imports the edited buffer directly back into the terminal prompt.
+
+## Attaching media [link](https://antigravity.google/\#attaching-media)
+
+Antigravity CLI supports pasting rich media formats directly from your system clipboard. Press `ctrl+v` (or native terminal paste) inside the prompt panel to attach screenshot mockups or video recordings.
+
+### Supported file types [link](https://antigravity.google/\#supported-file-types)
+
+- **Images**: PNG, JPEG, GIF, WebP, BMP, TIFF, and SVG.
+- **Videos**: MP4, MOV, WebM, and AVI.
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+After mastering interaction patterns, explore how the agent presents actions and requests verification:
+
+- **[Reviewing Artifacts](https://antigravity.google/docs/cli/artifacts)**: Learn to inspect and manage file edits, plans, and test executions.
+- **[Managing Conversations](https://antigravity.google/docs/cli/conversations)**: Resume prior threads and fork active sessions.
+- **[Background Tasks & Subagents](https://antigravity.google/docs/cli/subagents)**: Monitor asynchronous background agents.
+
+[Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Reviewing Artifacts](https://antigravity.google/docs/cli/artifacts)
+
+On this Page
+
+- Prompting & interaction
+
+- The prompt box
+
+- Multiline composition
+
+- Attaching media
+
+- Next steps

--- a/docs/docs-cli-sandbox.md
+++ b/docs/docs-cli-sandbox.md
@@ -1,0 +1,208 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities expand\_more
+
+[Choose an execution mode](https://antigravity.google/docs/cli/modes)
+
+[Subagents](https://antigravity.google/docs/cli/subagents)
+
+[Sandbox](https://antigravity.google/docs/cli/sandbox)
+
+[Permissions](https://antigravity.google/docs/cli/permissions)
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings chevron\_right
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Agent Capabilities
+>- Sandbox
+
+# Sandbox [link](https://antigravity.google/\#sandbox)
+
+Enforce native operating system process isolation, manage execution containment boundaries, and protect your local workstation.
+
+## The security model [link](https://antigravity.google/\#the-security-model)
+
+Because autonomous development agents run local terminal commands, edit source codes, and execute tests directly in your workspace, maintaining a secure workstation environment is critical. Antigravity CLI integrates a native **Terminal Sandbox** to restrict destructive shell operations or unauthorized remote network calls.
+
+### Native OS containment [link](https://antigravity.google/\#native-os-containment)
+
+Unlike heavy virtual containers or isolated virtual machines that slow down execution speeds, Antigravity uses lightweight, native operating system kernel utilities to create secure process rings with zero execution overhead:
+
+| Operating System | Sandboxing Utility | Security Characteristics |
+| --- | --- | --- |
+| **Linux** | `nsjail` | Open-source process isolator utilizing kernel namespaces and cgroups to confine CPU, memory, and path visibility. |
+| **macOS** | `sandbox-exec` | Native system tool enforcing policy profiles that restrict absolute filesystem access and raw TCP queries. |
+| **Windows** | `AppContainer` | Desktop security containment ring isolating filesystem permissions and registry visibility. |
+
+## Activating the sandbox [link](https://antigravity.google/\#activating-the-sandbox)
+
+You configure the sandbox directly inside your global preferences:
+
+text
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/settings.json
+
+```
+
+### Sandbox configurations [link](https://antigravity.google/\#sandbox-configurations)
+
+Add the sandboxing toggle to your settings profile:
+
+json
+
+content\_copy
+
+```
+            {
+  "enableTerminalSandbox": true
+}
+
+```
+
+- **`enableTerminalSandbox`** (boolean, default: `false`): Restricts all local execution commands launched by agents to OS containment rings.
+
+## Interactive approvals with sandbox [link](https://antigravity.google/\#interactive-approvals-with-sandbox)
+
+When the agent attempts to run a terminal tool or shell command, the TUI prompt block adapts dynamically based on your sandboxing state:
+
+- **When Sandbox is Enabled**: The prompt panel offers a temporary escape option:
+
+content\_copy
+
+```
+                Do you want to proceed?
+    1. Yes
+    2. Yes, and run without sandbox restrictions
+    3. No
+
+```
+
+Choosing Option 2 bypasses the containment barrier exclusively for that single execution run.
+
+- **When Sandbox is Disabled**: The prompt lets you force containment for a risky command:
+
+content\_copy
+
+```
+                Do you want to proceed?
+    1. Yes
+    2. Yes, and run in sandbox
+    3. No
+
+```
+
+## See also [link](https://antigravity.google/\#see-also)
+
+- **[Permissions Engine](https://antigravity.google/docs/cli/permissions)**: Configure fine-grained allow/deny policy rules.
+- **[Plugins & Skills](https://antigravity.google/docs/cli/plugins)**: Create your own custom skills slash commands.
+- **[Settings, Rendering & Keybindings](https://antigravity.google/docs/cli/settings)**: Customize keyboard hotkeys and buffers.
+
+[Background Tasks & Subagents](https://antigravity.google/docs/cli/subagents)
+
+[Settings, Rendering & Keybindings](https://antigravity.google/docs/cli/settings)
+
+On this Page
+
+- Sandbox
+
+- The security model
+
+- Activating the sandbox
+
+- Interactive approvals with sandbox
+
+- See also

--- a/docs/docs-cli-settings.md
+++ b/docs/docs-cli-settings.md
@@ -1,0 +1,330 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](https://antigravity.google/docs/cli/overview)
+
+[Getting Started](https://antigravity.google/docs/cli/getting-started)
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+[Gemini Migration](https://antigravity.google/docs/cli/gcli-migration)
+
+[Prompting](https://antigravity.google/docs/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](https://antigravity.google/docs/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](https://antigravity.google/docs/cli/projects)
+
+Settings expand\_more
+
+[Overview](https://antigravity.google/docs/cli/settings)
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[Troubleshooting](https://antigravity.google/docs/cli/troubleshooting)
+
+[Reference](https://antigravity.google/docs/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Settings
+>- Overview
+
+# Settings, rendering & keybindings [link](https://antigravity.google/\#settings-rendering-keybindings)
+
+Configure persistent preferences, customize keyboard shortcuts, toggle terminal display buffers, and manage runtime CLI parameter overrides.
+
+## Setting up preferences [link](https://antigravity.google/\#setting-up-preferences)
+
+Antigravity CLI stores user preferences in a minimal, forward-compatible JSON configuration profile.
+
+### Configuration file location [link](https://antigravity.google/\#configuration-file-location)
+
+The persistent settings are saved in a plain JSON format:
+
+text
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/settings.json
+
+```
+
+The CLI leverages **sparse persistence** by writing only values to disk that differ from their system defaults. This keeps your configuration file clean, minimal, and fully forward-compatible with future updates.
+
+### The interactive settings panel [link](https://antigravity.google/\#the-interactive-settings-panel)
+
+To edit settings directly inside your active terminal session without opening raw JSON files:
+
+1. Type `/config` (or its alias `/settings`) inside the prompt panel and press `Enter`.
+2. The full-screen **Settings Editor Overlay** opens.
+3. Navigate between available options using `↑`/`↓`.
+4. Press `Enter` on a highlighted parameter to toggle its state or open a text insertion field.
+5. Press `Esc` to save your modifications and close the editor.
+
+![The interactive settings panel](https://antigravity.google/assets/image/docs/cli/settings-interactive-panel.png)
+
+## Command-line overrides [link](https://antigravity.google/\#command-line-overrides)
+
+You can temporarily override persistent preferences for individual terminal sessions using CLI command flags:
+
+bash
+
+content\_copy
+
+```
+            agy --sandbox --model="Gemini 3.5 Flash"
+
+```
+
+When an override flag is active, the interactive `/config` menu displays a warning indicator alongside the modified setting:
+
+text
+
+content\_copy
+
+```
+            ! Tool Permission: strict (overridden by command flag)
+
+```
+
+You can still edit the persistent value on disk during these sessions, but the CLI enforces the active runtime flag override until you close the session.
+
+## Visual rendering modes [link](https://antigravity.google/\#visual-rendering-modes)
+
+The TUI operates in one of two visual rendering modes depending on your terminal capability and connection latency.
+
+### Alt-screen mode (\`always\`) [link](https://antigravity.google/\#alt-screen-mode-always)
+
+This mode opens a dedicated display screen using the terminal's alternate buffer, creating an immersive, standalone app interface.
+
+- **Key features**: Integrated scrollback, mouse-wheel scrolling support, custom rendered scrollbar, and clean terminal state restoration on exit.
+- **Best used for**: Standard local development sessions in advanced terminal emulators (such as iTerm2, Ghostty, or WezTerm).
+
+### Inline mode (\`never\`) [link](https://antigravity.google/\#inline-mode-never)
+
+This mode renders output sequentially directly within your terminal's standard stdout pipeline.
+
+- **Key features**: Preserves entire session history inside your emulator's native scrollback buffer, does not capture mouse inputs, and works seamlessly alongside standard command outputs.
+- **Best used for**: Remote SSH terminals, terminal multiplexers like `tmux` or `screen`, and low-bandwidth remote sessions.
+
+info
+
+**Adaptive Rendering**: Setting Alt-Screen mode to `default` allows the TUI to automatically detect your environment. It defaults to Alt-Screen on advanced local shells and degrades to Inline mode when running over SSH or in non-interactive sessions.
+
+## Configuration options reference [link](https://antigravity.google/\#configuration-options-reference)
+
+The interactive settings panel (`/config`) and `settings.json` allow you to customize the CLI's behavior across several categories.
+
+### Safety & permissions [link](https://antigravity.google/\#safety-permissions)
+
+Manage how the agent interacts with your system and codebase:
+
+- **Tool Permission (`toolPermission`)**: Controls the authorization flow for tools (such as running terminal commands).
+- `request-review` (Default): Prompts for your approval before running write, bash, or web tools.
+- `proceed-in-sandbox`: Automatically runs terminal commands if they are sandboxed; otherwise prompts for review.
+- `strict`: Prompts for all non-read tools, ensuring maximum control.
+- `always-proceed`: Runs all tools without prompting (highest risk, use with caution).
+- **Artifact Review (`artifactReviewPolicy`)**: Controls when the agent prompts you to review generated artifacts (like code files) before writing them to disk.
+- `asks-for-review` (Default): Always prompts you to review changes.
+- `agent-decides`: The agent decides whether to prompt based on the complexity of the change.
+- `always-proceed`: The agent writes changes directly without prompting (maximizes autonomy, but increases risk of overwriting code without review).
+- **Sandbox Mode (`enableTerminalSandbox`)**: When enabled (`on`), restricts all agent-initiated terminal commands to a secure OS container.
+- **Non-Workspace Access (`allowNonWorkspaceAccess`)**: Controls whether the agent can read or write files outside your active project directories. Set to `off` by default for safety.
+
+### Display & rendering [link](https://antigravity.google/\#display-rendering)
+
+Customize the visual experience of the TUI:
+
+- **Rendering Mode (`altScreenMode`)**: Controls how the TUI utilizes your terminal buffer.
+- `default`: Adaptive mode. Uses Alt-screen on advanced local terminals and degrades to inline mode over SSH.
+- `always`: Forces Alt-screen mode, providing an immersive, page-based interface with mouse support and scrollbars.
+- `never` (configurable via `settings.json`): Forces inline mode, rendering output sequentially and preserving history in your emulator's scrollback.
+- **Color Scheme (`colorScheme`)**: Selects the visual theme. Options include `terminal` (inherits shell colors), `dark`, `light`, `solarized dark/light`, `tokyo night`, and colorblind-friendly variants.
+- **Animation Speed (`runningLightSpeed`)**: Adjusts the speed of the progress indicator animation (`fast`, `medium`, `slow`, or `off`).
+- **Verbosity (`verbosity`)**: Controls detail level. `high` shows full agent thoughts and tool steps; `low` shows only minimal progress indicators.
+
+### Editor & notifications [link](https://antigravity.google/\#editor-notifications)
+
+Configure integrations with your host environment:
+
+- **Editor (`editor`)**: The text editor used to view artifacts or compose prompts (via `Ctrl+G`). Defaults to `auto` (respects `$EDITOR`), but can be set to `vim`, `emacs`, or others.
+- **Notifications (`notifications`)**: When enabled (`on`), triggers a system desktop notification and a terminal bell chime when a long-running task completes or requires your attention.
+
+### AI Credits & Feedback [link](https://antigravity.google/\#ai-credits-feedback)
+
+Manage usage, tips, and telemetry:
+
+- **Use AI Credits (`useG1Credits`)**: _External builds only._ When enabled (`on`), allows the CLI to use your personal AI credits for model calls if your plan's standard quota is exhausted.
+- **Enable Telemetry (`enableTelemetry`)**: Helps Google improve the tool by sending anonymous usage statistics and crash reports.
+- **Show Tips (`showTips`)**: Toggles the display of helpful usage tips while the agent is generating responses.
+- **Show Feedback Survey (`showFeedbackSurvey`)**: Enables periodic brief surveys after task completions to help improve the experience.
+
+## Custom status lines & terminal titles [link](https://antigravity.google/\#custom-status-lines-terminal-titles)
+
+For advanced TUI environment integrations, you can toggle active metrics or deploy custom scripts to generate dynamic status bars and modify your terminal window titles:
+
+- **[Status Line Customization](https://antigravity.google/docs/cli/commands/statusline)**: Learn how to manage the status indicator panel and construct custom formatted status line shell scripts.
+- **[Terminal Title Customization](https://antigravity.google/docs/cli/commands/title)**: Learn how to toggle window title outputs and pipe live agent states into your window headers.
+
+## Keybindings configuration [link](https://antigravity.google/\#keybindings-configuration)
+
+You can customize almost all keyboard shortcuts in the TUI by mapping keys to specific workspace commands.
+
+### Keybindings file location [link](https://antigravity.google/\#keybindings-file-location)
+
+Custom maps are stored alongside your primary settings profile:
+
+text
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/keybindings.json
+
+```
+
+### Format and customization [link](https://antigravity.google/\#format-and-customization)
+
+The JSON structure maps a single TUI command action to an array of hotkey sequences:
+
+json
+
+content\_copy
+
+```
+            {
+  "cli.clear_screen": [\
+    "ctrl+l"\
+  ],
+  "prompt.insert_newline": [\
+    "shift+enter",\
+    "ctrl+j"\
+  ],
+  "edit.open_editor": [\
+    "ctrl+g"\
+  ]
+}
+
+```
+
+To completely disable a default hotkey, map its action to an empty array `[]`. If your JSON schema is malformed or invalid, the CLI falls back to system defaults for those specific actions and loads the remaining valid mappings.
+
+warning
+
+**Protected Keys**: Crucial navigation shortcuts like `cli.exit` (`Ctrl+D` / `Ctrl+C`) and `cli.enter` (`Enter`) are protected by the system and cannot be disabled.
+
+### Restoring defaults [link](https://antigravity.google/\#restoring-defaults)
+
+To revert all keys back to system defaults, delete the keybindings profile:
+
+bash
+
+content\_copy
+
+```
+            rm ~/.gemini/antigravity-cli/keybindings.json
+
+```
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Now that you have configured your environment, review security controls and extensibility options:
+
+- **[Permissions & Sandbox](https://antigravity.google/docs/cli/sandbox)**: Manage secure execution containment boundaries.
+- **[Plugins & Skills](https://antigravity.google/docs/cli/plugins)**: Create your own custom skills and import legacy plugins.
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: Access quick reference sheets listing all configuration options, commands, and default key maps.
+
+[Sandbox](https://antigravity.google/docs/cli/sandbox)
+
+[AI Credits](https://antigravity.google/docs/cli/credits)
+
+On this Page
+
+- Settings, rendering & keybindings
+
+- Setting up preferences
+
+- Command-line overrides
+
+- Visual rendering modes
+
+- Configuration options reference
+
+- Custom status lines & terminal titles
+
+- Keybindings configuration
+
+- Next steps

--- a/docs/docs-cli-troubleshooting.md
+++ b/docs/docs-cli-troubleshooting.md
@@ -1,0 +1,304 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Troubleshooting
+
+# Troubleshooting [link](https://antigravity.google/\#troubleshooting)
+
+Diagnose and resolve common anomalies with installation PATHs, local self-updating locks, keyring access permissions, and SSH clipboard forwarding.
+
+## Quick reference [link](https://antigravity.google/\#quick-reference)
+
+Scan the lookup table below to identify symptoms and access immediate solutions:
+
+| Error Symptom | Potential Cause | Target Resolution |
+| --- | --- | --- |
+| **`agy: command not found`** | Binary directory missing from shell environments. | [Configure your shell PATH](https://antigravity.google/#configure-your-shell-path) |
+| **`keyring: secure lock out`** | Missing system service permissions or active lockouts. | [Authorize keyring permissions](https://antigravity.google/#authorize-keyring-permissions) |
+| **`SSH Clipboard paste failures`** | Protocol streams blocked or missing forward configurations. | [Enable emulator clipboard forwarding](https://antigravity.google/#enable-emulator-clipboard-forwarding) |
+| **`Advisory lock / update failures`** | Locked self-updater thread or read-only directory paths. | [Resolve self-updater locks and failures](https://antigravity.google/#resolve-self-updater-locks-and-failures) |
+
+\-\-\-
+
+## Configure your shell PATH [link](https://antigravity.google/\#configure-your-shell-path)
+
+### Symptom [link](https://antigravity.google/\#symptom)
+
+Executing `agy` returns a shell terminal error:
+
+bash
+
+content\_copy
+
+```
+            bash: agy: command not found
+
+```
+
+### Cause [link](https://antigravity.google/\#cause)
+
+The installation utility downloads the binary to `~/.local/bin` (or `C:\Users\<Username>\AppData\Local\agy\bin`), but your shell's active `$PATH` environment does not index this directory.
+
+### Resolution [link](https://antigravity.google/\#resolution)
+
+Ensure your terminal session loads the binary path.
+
+**macOS & Linux**:
+
+1. Open your shell configuration file (`~/.bashrc` or `~/.zshrc`).
+2. Verify or append the following line at the end of the file:
+
+content\_copy
+
+```
+                export PATH="~/.local/bin:$PATH"
+
+```
+
+1. Reload your profile configurations:
+
+content\_copy
+
+```
+                source ~/.zshrc
+
+```
+
+**Windows (PowerShell)**:
+
+1. Open a PowerShell terminal as an Administrator and execute:
+
+content\_copy
+
+```
+                [System.Environment]::SetEnvironmentVariable("Path", [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\Program Files\Google\antigravity-cli", "User")
+
+```
+
+1. Restart your terminal emulator for the system registry environment to refresh.
+
+\-\-\-
+
+## Authorize keyring permissions [link](https://antigravity.google/\#authorize-keyring-permissions)
+
+### Symptom [link](https://antigravity.google/\#symptom-2)
+
+When launching, the CLI hangs, prints DBUS warnings, or throws keyring access exceptions:
+
+text
+
+content\_copy
+
+```
+            Error: failed to retrieve token: secret keyring is locked
+
+```
+
+### Cause [link](https://antigravity.google/\#cause-2)
+
+Antigravity CLI utilizes secure keychain libraries (Apple Keychain, Linux secret-service via dbus, or Windows Credential Manager) to encrypt your session tokens. If the background daemon is locked or headless, the CLI cannot read credentials.
+
+### Resolution [link](https://antigravity.google/\#resolution-2)
+
+**macOS**:
+
+1. Open **Keychain Access** app.
+2. Search for the `Antigravity CLI` security item.
+3. Right-click, select **Get Info**, choose the **Access Control** tab, and verify that `agy` is on the allowed applications list.
+4. If running inside a headless SSH session on Mac, run the following unlock sequence:
+
+content\_copy
+
+```
+                security unlock-keychain -p "your_keychain_password" login.keychain
+
+```
+
+**Linux**:
+
+Ensure your system keyring (such as GNOME Keyring or KWallet) is unlocked and accessible.
+
+If you are running in a headless environment or over SSH, ensure that a D-Bus session is active and that your keyring daemon is running. You can typically initialize a D-Bus session by running:
+
+bash
+
+content\_copy
+
+```
+            export $(dbus-launch)
+
+```
+
+If you still experience access issues, ensure your user account has the necessary permissions to access the keyring service or reach out to support.
+
+\-\-\-
+
+## Enable emulator clipboard forwarding [link](https://antigravity.google/\#enable-emulator-clipboard-forwarding)
+
+### Symptom [link](https://antigravity.google/\#symptom-3)
+
+Pasting screenshots or media files via `Ctrl+V` within an SSH terminal returns a failure notification:
+
+text
+
+content\_copy
+
+```
+            Error: local pasteboard is empty or unreachable over SSH connection
+
+```
+
+### Cause [link](https://antigravity.google/\#cause-3)
+
+Standard SSH streams do not forward graphical clipboards. Graphic uploads require specific terminal multiplexer protocols.
+
+### Resolution [link](https://antigravity.google/\#resolution-3)
+
+Verify that you are utilizing supported terminal emulators and configurations.
+
+1. **Use iTerm2 or Ghostty**: These emulators support advanced clip channels.
+2. **Configure iTerm2 Forwarding**:
+
+- Open iTerm2 Preferences (`Cmd+,`).
+- Go to the **General** tab, select **Selection** submenu.
+- Check **Applications in terminal may access clipboard** (enabling OSC 52 write channels).
+
+1. **Bypass Multiplexers**: If running inside `tmux`, ensure your active configuration maps standard paste clips correctly:
+
+content\_copy
+
+```
+                set -s set-clipboard on
+
+```
+
+\-\-\-
+
+## Resolve self-updater locks and failures [link](https://antigravity.google/\#resolve-self-updater-locks-and-failures)
+
+### Symptom [link](https://antigravity.google/\#symptom-4)
+
+Launching `agy` hangs, fails to apply upgrades, or returns an advisory lock warning:
+
+text
+
+content\_copy
+
+```
+            Warning: another background updater process is already active (update.lock)
+
+```
+
+### Cause [link](https://antigravity.google/\#cause-4)
+
+Antigravity CLI contains a native, statically linked self-updater that runs in the background. It uses a 15-minute Time-To-Live (TTL) debounce marker (`last_check.timestamp`) and an advisory lock (`update.lock`) inside `~/.gemini/antigravity-cli/updater/` to prevent concurrent process collisions. If a background updater process hangs, crashes without releasing the lock, or has insufficient user filesystem permissions inside the executable directory, subsequent updates are blocked.
+
+### Resolution [link](https://antigravity.google/\#resolution-4)
+
+- **Release the advisory lock**: Purge the background lock file manually:
+
+content\_copy
+
+```
+                rm -f ~/.gemini/antigravity-cli/updater/update.lock
+
+```
+
+- **Opt-out/Disable auto-updates**: Set the `AGY_CLI_DISABLE_AUTO_UPDATE` environment variable to `true` inside your shell profile (`~/.bashrc` or `~/.zshrc`):
+
+content\_copy
+
+```
+                export AGY_CLI_DISABLE_AUTO_UPDATE=true
+
+```
+
+- **Verify directory write permissions**: Ensure your user profile owns and has write permissions inside the target installation directory (`~/.local/bin/` on Unix, or `%LOCALAPPDATA%\agy\bin` on Windows).
+
+\-\-\-
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Access our quick reference sheets or configure advanced permissions:
+
+- **[CLI Reference](https://antigravity.google/docs/cli/reference)**: Dense tables listing all slash commands and visual settings keys.
+- **[Permissions](https://antigravity.google/docs/cli/permissions)**: Configure fine-grained allowed and denied action policies.
+- **[Sandbox](https://antigravity.google/docs/cli/sandbox)**: Enforce OS-level container isolation boundaries.
+- **[Plugins & Skills](https://antigravity.google/docs/cli/plugins)**: Create your own custom skills.
+
+[Best Practices](https://antigravity.google/docs/cli/best-practices)
+
+[CLI Reference](https://antigravity.google/docs/cli/reference)
+
+On this Page
+
+- Troubleshooting
+
+- Quick reference
+
+- Configure your shell PATH
+
+- Authorize keyring permissions
+
+- Enable emulator clipboard forwarding
+
+- Resolve self-updater locks and failures
+
+- Next steps

--- a/docs/docs-cli-tutorial.md
+++ b/docs/docs-cli-tutorial.md
@@ -1,0 +1,146 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Tutorial
+
+# Antigravity CLI Tutorial [link](https://antigravity.google/\#antigravity-cli-tutorial)
+
+Learn how to launch Antigravity CLI, collaborate with an autonomous local agent, review generated files, and execute terminal test commands.
+
+## Overview [link](https://antigravity.google/\#overview)
+
+This guide walks you through a rapid onboarding exercise. You will direct an autonomous agent to create a Python utility script, review the changes, and verify its execution.
+
+## Step-by-step [link](https://antigravity.google/\#step-by-step)
+
+1. Create a clean project directory and launch the Antigravity TUI
+
+content\_copy
+
+```
+                mkdir agy-demo && cd agy-demo
+    agy
+
+```
+
+info
+
+**First Launch**: If running `agy` for the first time, follow the terminal instructions to complete silent authentication. See [Installation & Auth](https://antigravity.google/docs/cli/install) for troubleshooting details.
+
+1. Prompt the agent to generate a Python scraping script
+
+Type the following instruction in the prompt box at the bottom of your screen and press `Enter`:
+
+content\_copy
+
+```
+                Write a simple python script to fetch web page text
+
+```
+
+The agent reads the workspace, determines that no files exist, and formulates a plan to create a script. You will see real-time updates as the agent performs reasoning and schedules actions.
+
+1. Open the artifact review screen to inspect the proposed code
+
+Once the agent finishes generating the file, a notification appears. Press `ctrl+r` to enter the **Artifact Review** screen.
+
+- Navigate to the newly created `main.py` using `↑`/`↓`.
+- Review the complete file content and diff.
+- Press `y` to approve the creation of `main.py`.
+- Press `Esc` to close the review panel and return to the primary prompt.
+
+1. Execute a test command with the agent to verify the output
+
+Direct the agent to run the Python script to verify its behavior. Type the following command in the prompt box and press `Enter`:
+
+content\_copy
+
+```
+                Run the python script and show me the output
+
+```
+
+The agent proposes to run `python3 main.py`. Press `y` to confirm and execute the command. The agent runs the script locally and streams the standard output directly into your terminal screen.
+
+1. Exit the Antigravity session
+
+Once you complete your task, press `ctrl+d` (or type `/exit`) in the prompt box to close the TUI and restore your original shell session.
+
+## Next steps [link](https://antigravity.google/\#next-steps)
+
+Now that you have executed your first agent-assisted workflow, learn how to configure the CLI and master core concepts:
+
+- **[Installation & Auth](https://antigravity.google/docs/cli/install)**: Detailed instructions on installing `agy` and setting up SSH profiles.
+- **[Prompting & Interaction](https://antigravity.google/docs/cli/prompting)**: Best practices for multiline inputs, pasting media files, and active interrupt controls.
+- **[Reviewing Artifacts](https://antigravity.google/docs/cli/artifacts)**: Deep dive into the "Trust through Transparency" architectural pattern.
+
+[Installation & Auth](https://antigravity.google/docs/cli/install)
+
+[Using AGY CLI](https://antigravity.google/docs/cli/using)
+
+On this Page
+
+- Antigravity CLI Tutorial
+
+- Overview
+
+- Step-by-step
+
+- Next steps

--- a/docs/docs-cli-using.md
+++ b/docs/docs-cli-using.md
@@ -1,0 +1,140 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Using AGY CLI
+
+# Using AGY CLI [link](https://antigravity.google/\#using-agy-cli)
+
+### Settings [link](https://antigravity.google/\#settings)
+
+Antigravity CLI provides a flexible configuration system to customize workspace behavior, safety restrictions, editor preferences, visual style, and performance.
+
+- **Configuration File**: Stored in a plain JSON file `~/.gemini/antigravity-cli/settings.json`.
+- **Settings Panel**: Type `/config` or `/settings` to open a full-screen overlay menu listing all available options.
+- Select a setting to open its list of options or a text input field.
+- Immediately save your selection to the disk and return to the main list.
+- **Overrides**: Certain settings can be overridden at launch via CLI flags (e.g., `--sandbox` or `--dangerously-skip-permissions`).
+- The settings menu will display an indicator showing where the override came from (e.g., _Sandbox Mode on overridden by `--sandbox`_).
+- You can still edit the persistent setting on disk, but the current session will enforce the command-line override until restarted.
+
+### Quick Tips [link](https://antigravity.google/\#quick-tips)
+
+| Action/Feature | Tip/Command |
+| --- | --- |
+| **Auto-complete to file paths** | `@` will trigger path suggestions |
+| **Clear Prompt** | Type `esc esc` to clear your prompt box (when no streaming is active) |
+| **Terminal Commands** | Use `!` at the start of your prompt to run terminal commands directly |
+| **Help** | Type `?` to get help and list all slash commands |
+| **Reduce Noise from Tool Calls** | Set verbosity to **low** in `/config` to minimize outputs from numerous tool calls |
+| **Manage Permissions** | Control permissions via `/config` or `/permissions` |
+| **Go Back in Conversation** | Use `/rewind` or `/undo` to rewind the conversation history |
+| **Fork Conversation** | Use `/fork` to spin up a separate workspace and branch the conversation from an earlier point |
+| **Clear Conversation** | Use `/clear` to clear the prompt and start a new conversation session |
+| **Resume Conversation** | Use `/resume` to list and resume previous conversation logs |
+| **Auto-Save Resume** | When you close the CLI, it automatically prints the exact command needed to resume that specific session |
+
+### Keybindings [link](https://antigravity.google/\#keybindings)
+
+AGY CLI allows for custom keybindings. You can edit them by typing `/keybindings` or modifying the JSON file directly.
+
+- **File Location**: `~/.gemini/antigravity-cli/keybindings.json`.
+- **Reset**: To reset to default, delete the `keybindings.json` file.
+
+**Default Keybindings**
+
+| Action/Command | Keys | Purpose |
+| --- | --- | --- |
+| **Clear TUI Screen** | `ctrl+l` | Clear terminal output |
+| **Enter / Submit** | `enter` | Submit prompts or choices |
+| **Escape / Cancel** | `ctrl+c`, `esc` | Stop stream, close menus, or clear prompt |
+| **Exit CLI** | `ctrl+d` | Terminate CLI TUI session |
+| **Suspend CLI** | `ctrl+z` | Push CLI session to terminal background |
+| **Edit Command** | `e` | Open editor to edit proposed terminal command |
+| **Confirm No** | `n` | Decline terminal command execution |
+| **Confirm Yes** | `y` | Approve terminal command execution |
+| **Open Editor** | `ctrl+g` | Edit prompt inside your default shell editor |
+| **Paste Text** | `ctrl+v` | Paste text from your clipboard |
+| **Redo Text Edit** | `ctrl+shift+z` | Redo last undone text change |
+| **Undo Text Edit** | `ctrl+_`, `ctrl+shift+-` | Undo last text change |
+| **Yank (Copy)** | `ctrl+y` | Yank/copy selected text |
+| **Navigate Down** | `down` | Scroll down in menu lists |
+| **Go to Bottom** | `ctrl+end` | Jump TUI view directly to the bottom |
+| **Go to Top** | `ctrl+home` | Jump TUI view directly to the top |
+| **Navigate Left** | `left` | Move prompt cursor left |
+| **Page Down** | `pgdown`, `shift+down` | Scroll TUI page down |
+| **Page Up** | `pgup`, `shift+up` | Scroll TUI page up |
+| **Navigate Right** | `right` | Move prompt cursor right |
+| **Tab / Focus** | `tab` | Auto-complete choices or switch component focus |
+| **Navigate Up** | `up` | Scroll up in menu lists |
+| **Insert Newline** | `alt+enter`, `ctrl+j`, `shift+enter` | Add newline to prompt without submitting |
+
+You can map a single action to many keybindings in the JSON file. To disable keybindings, set the list to empty (e.g., `[]`). If the file is malformed, the CLI will use the valid parts and fall back to defaults for the broken actions.
+
+warning
+
+**Important**: Keybindings `cli.exit` and `cli.enter` cannot be disabled.
+
+[Tutorial](https://antigravity.google/docs/cli/tutorial)
+
+[Features](https://antigravity.google/docs/cli/features)
+
+On this Page
+
+- Using AGY CLI

--- a/docs/docs-enterprise.md
+++ b/docs/docs-enterprise.md
@@ -1,0 +1,177 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Enterprise
+
+# Getting Started with Antigravity and Gemini Enterprise Agent Platform [link](https://antigravity.google/\#getting-started-with-antigravity-and-gemini-enterprise-agent-platform)
+
+Supported products: Antigravity 2.0Antigravity CLI
+
+This guide is for administrators setting up the Google Cloud environment to enable Antigravity integration with Gemini Enterprise Agent Platform. This integration allows enterprise developers to use Antigravity with models hosted in your own Google Cloud project, under Google Cloud Terms of Service, satisfying private networking and data residency requirements, and utilizing consumption-based billing.
+
+info
+
+**Note**: Integration is only supported for Antigravity 2.0 and Antigravity CLI. Antigravity IDE is not supported for enterprise customers.
+
+[Supported Models](https://antigravity.google/docs/models)
+
+## Basic Setup [link](https://antigravity.google/\#basic-setup)
+
+### Prerequisites [link](https://antigravity.google/\#prerequisites)
+
+Before you begin, ensure you have:
+
+- A Google Cloud account.
+- Access to the Google Cloud console.
+
+### Step 1: Select or Create a Google Cloud Project [link](https://antigravity.google/\#step-1-select-or-create-a-google-cloud-project)
+
+In the Google Cloud console, on the project selector page, select or create a Google Cloud project.
+
+### Roles Required to Select or Create a Project [link](https://antigravity.google/\#roles-required-to-select-or-create-a-project)
+
+- **Select a project**: Selecting a project doesn't require a specific IAM role—you can select any project that you've been granted a role on.
+
+info
+
+**Note**: To switch to a different Google Cloud project or location, you must first log out of the Antigravity CLI or Hub, then log back in and select your new project/location. Directly changing the project or location while logged in is currently not supported.
+
+- **Create a project**: To create a project, you need the **Project Creator** role (`roles/resourcemanager.projectCreator`), which contains the `resourcemanager.projects.create` permission. [Learn how to grant roles](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
+
+info
+
+**Note**: If you don't plan to keep the resources that you create in this procedure, create a new project instead of selecting an existing project. After you finish these steps, you can delete the project to remove all associated resources.
+
+[Go to project selector](https://console.cloud.google.com/projectselector2)
+
+### Step 2: Verify Billing [link](https://antigravity.google/\#step-2-verify-billing)
+
+Verify that billing is enabled for your Google Cloud project. You can check the billing status in the [Google Cloud Billing Console](https://console.cloud.google.com/billing). For detailed instructions, see [Verify the billing status of your projects](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled).
+
+### Step 3: Enable the Agent Platform API [link](https://antigravity.google/\#step-3-enable-the-agent-platform-api)
+
+To use Antigravity with Gemini Enterprise Agent Platform, you must enable the Agent Platform API (`aiplatform.googleapis.com`).
+
+### Roles Required to Enable APIs [link](https://antigravity.google/\#roles-required-to-enable-apis)
+
+To enable APIs, you need the **Service Usage Admin** IAM role (`roles/serviceusage.serviceUsageAdmin`), which contains the `serviceusage.services.enable` permission. [Learn how to grant roles](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
+
+### Enable the API [link](https://antigravity.google/\#enable-the-api)
+
+[Enable the Agent Platform API in the API Library](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com)
+
+### User Permissions [link](https://antigravity.google/\#user-permissions)
+
+To get the permissions that you need to use Gemini Enterprise Agent Platform, ask your administrator to grant you the **Agent Platform User** (`roles/aiplatform.user`) IAM role on your project. For more information about granting roles, see [Manage access to projects, folders, and organizations](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
+
+You might also be able to get the required permissions through [custom roles](https://cloud.google.com/iam/docs/creating-custom-roles) or other [predefined roles](https://cloud.google.com/iam/docs/roles-overview#predefined).
+
+## Advanced Configuration [link](https://antigravity.google/\#advanced-configuration)
+
+### Request and Response Logging [link](https://antigravity.google/\#request-and-response-logging)
+
+For detailed instructions on how to enable and configure request and response logging for the Gemini Enterprise Agent Platform, please refer to the official documentation:
+
+[Request and Response Logging Documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/request-response-logging)
+
+### VPC Service Controls (VPC-SC) [link](https://antigravity.google/\#vpc-service-controls-vpc-sc)
+
+If your organization has a service perimeter, then you must add the following resources to your perimeter:
+
+- Agent Platform API
+
+For detailed instructions on how to configure VPC Service Controls, please refer to the official documentation:
+
+[VPC Service Controls Documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/vpc-service-controls)
+
+## Complementary Resources [link](https://antigravity.google/\#complementary-resources)
+
+### Consumption Options [link](https://antigravity.google/\#consumption-options)
+
+Gemini Enterprise Agent Platform offers different consumption options to suit your needs.
+
+For detailed information on consumption options, please refer to the official documentation:
+
+[Consumption Options Documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/deploy/consumption-options)
+
+### Deployments and Endpoints Locations [link](https://antigravity.google/\#deployments-and-endpoints-locations)
+
+For now, Antigravity CLI and 2.0 offer 3 endpoints: global, multi-region eu, and multi-region us.
+
+info
+
+**Note**: Image generation is currently not available in `eu` and `us` locations.
+
+For a full list of available locations and deployment endpoints, please refer to the official documentation:
+
+[Deployment Endpoints Documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations#global)
+
+[Firebase Studio Migration](https://antigravity.google/docs/firebase-studio-migration)
+
+[Plans](https://antigravity.google/docs/plans)
+
+On this Page
+
+- Getting Started with Antigravity and Gemini Enterprise Agent Platform
+
+- Basic Setup
+
+- Advanced Configuration
+
+- Complementary Resources

--- a/docs/docs-faq.md
+++ b/docs/docs-faq.md
@@ -1,0 +1,408 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- FAQ
+
+# FAQ [link](https://antigravity.google/\#faq)
+
+## Why can I not authenticate into Google Antigravity? [link](https://antigravity.google/\#why-can-i-not-authenticate-into-google-antigravity)
+
+Google Antigravity is currently available for personal Google accounts in approved geographies. Please try using an @gmail.com email address if having challenges with Workspace Google accounts.
+
+## Why is my age unverified? [link](https://antigravity.google/\#why-is-my-age-unverified)
+
+At the moment, Antigravity is unavailable to under-18 users. If you do meet the minimum age requirement, you may [verify your age](https://myaccount.google.com/age-verification) to continue using Antigravity.
+
+## What is Google Antigravity’s geographical availability? [link](https://antigravity.google/\#what-is-google-antigravitys-geographical-availability)
+
+Google Antigravity is available in the following countries and territories. If you're not in one of these countries or territories, you will be unable to use Google Antigravity at this time:
+
+**Important**: Please check the country listed on the [Google Terms of Service](https://policies.google.com/terms) page. If this is the wrong country, you may [submit a request](https://policies.google.com/country-association-form) to change your associated region.
+
+Americas
+
+- American Samoa
+- Anguilla
+- Antigua and Barbuda
+- Argentina
+- Aruba
+- The Bahamas
+- Barbados
+- Belize
+- Bermuda
+- Bolivia
+- Brazil
+- British Virgin Islands
+- Canada
+- Caribbean Netherlands
+- Cayman Islands
+- Chile
+- Colombia
+- Costa Rica
+- Curaçao
+- Dominica
+- Dominican Republic
+- Ecuador
+- El Salvador
+- Falkland Islands (Islas Malvinas)
+- Greenland
+- Grenada
+- Guatemala
+- Guyana
+- Haiti
+- Honduras
+- Jamaica
+- Mexico
+- Montserrat
+- Nicaragua
+- Panama
+- Paraguay
+- Peru
+- Puerto Rico
+- Saint Barthélemy
+- Saint Kitts and Nevis
+- Saint Lucia
+- Saint Pierre and Miquelon
+- Saint Vincent and the Grenadines
+- South Georgia and the South Sandwich Islands
+- Suriname
+- Trinidad and Tobago
+- Turks and Caicos Islands
+- United States
+- Uruguay
+- U.S. Virgin Islands
+- Venezuela
+
+Europe
+
+- Albania
+- Armenia
+- Austria
+- Azerbaijan
+- Belgium
+- Bosnia and Herzegovina
+- Bulgaria
+- Croatia
+- Cyprus
+- Czech Republic
+- Denmark
+- Estonia
+- Faroe Islands
+- Finland
+- France
+- Georgia
+- Germany
+- Gibraltar
+- Greece
+- Guernsey
+- Hungary
+- Iceland
+- Ireland
+- Isle of Man
+- Italy
+- Jersey
+- Kosovo
+- Latvia
+- Liechtenstein
+- Lithuania
+- Luxembourg
+- Malta
+- Montenegro
+- Netherlands
+- North Macedonia
+- Norway
+- Poland
+- Portugal
+- Romania
+- Serbia
+- Slovakia
+- Slovenia
+- Spain
+- Sweden
+- Switzerland
+- Ukrainian territories other than Crimea, the so-called Donetsk People's Republic ("DNR"), and the so-called Luhansk People's Republic ("LNR")
+- United Kingdom
+
+Africa
+
+- Algeria
+- Angola
+- Benin
+- Botswana
+- Burkina Faso
+- Burundi
+- Cabo Verde
+- Cameroon
+- Central African Republic
+- Chad
+- Comoros
+- Côte d'Ivoire
+- Democratic Republic of the Congo
+- Djibouti
+- Egypt
+- Equatorial Guinea
+- Eritrea
+- Eswatini
+- Ethiopia
+- Gabon
+- The Gambia
+- Ghana
+- Guinea
+- Guinea-Bissau
+- Kenya
+- Lesotho
+- Liberia
+- Libya
+- Madagascar
+- Malawi
+- Mali
+- Mauritania
+- Mauritius
+- Morocco
+- Mozambique
+- Namibia
+- Niger
+- Nigeria
+- Republic of the Congo
+- Rwanda
+- Saint Helena, Ascension and Tristan da Cunha
+- São Tomé and Príncipe
+- Senegal
+- Seychelles
+- Sierra Leone
+- Somalia
+- South Africa
+- South Sudan
+- Sudan
+- Tanzania
+- Togo
+- Tunisia
+- Uganda
+- Western Sahara
+- Zambia
+- Zimbabwe
+
+Asia
+
+- Bahrain
+- Bangladesh
+- Bhutan
+- British Indian Ocean Territory
+- Brunei
+- Cambodia
+- Christmas Island
+- Cocos (Keeling) Islands
+- India
+- Indonesia
+- Iraq
+- Israel
+- Japan
+- Jordan
+- Kazakhstan
+- Kuwait
+- Kyrgyzstan
+- Laos
+- Lebanon
+- Malaysia
+- Maldives
+- Mongolia
+- Nepal
+- Oman
+- Pakistan
+- Palestine
+- Philippines
+- Qatar
+- Saudi Arabia
+- Singapore
+- South Korea
+- Sri Lanka
+- Taiwan
+- Tajikistan
+- Thailand
+- Timor-Leste
+- Türkiye
+- Turkmenistan
+- United Arab Emirates
+- Uzbekistan
+- Vietnam
+- Yemen
+
+Oceania
+
+- Australia
+- Cook Islands
+- Fiji
+- Guam
+- Heard Island and McDonald Islands
+- Kiribati
+- Marshall Islands
+- Micronesia
+- Nauru
+- New Caledonia
+- New Zealand
+- Niue
+- Norfolk Island
+- Northern Mariana Islands
+- Palau
+- Papua New Guinea
+- Pitcairn Islands
+- Samoa
+- Solomon Islands
+- Tokelau
+- Tonga
+- Tuvalu
+- United States Minor Outlying Islands
+- Vanuatu
+- Wallis and Futuna
+
+Antarctica
+
+- Antarctica
+
+## Why am I ineligible for a Google One AI plan? [link](https://antigravity.google/\#why-am-i-ineligible-for-a-google-one-ai-plan)
+
+The following regions do not currently have access to Google One AI plans:
+
+- Antarctica
+- Brunei
+- Caribbean Netherlands
+- Curaçao
+- Democratic Republic of the Congo
+- Eswatini
+- Falkland Islands (Islas Malvinas)
+- Faroe Islands
+- Greenland
+- Guernsey
+- Heard Island and McDonald Islands
+- Isle of Man
+- Jersey
+- Kosovo
+- Montenegro
+- New Caledonia
+- Pitcairn Islands
+- Republic of the Congo
+- Saint Barthélemy
+- Saint Helena, Ascension and Tristan da Cunha
+- Saint Kitts and Nevis
+- Saint Vincent and the Grenadines
+- São Tomé and Príncipe
+- South Georgia and the South Sandwich Islands
+- South Sudan
+- Sudan
+- The Gambia
+- Türkiye
+- United States Minor Outlying Islands
+- U.S. Virgin Islands
+- Wallis and Futuna
+
+## What is Google Antigravity’s stance on data collection? [link](https://antigravity.google/\#what-is-google-antigravitys-stance-on-data-collection)
+
+Please refer to the [Terms of Service](https://antigravity.google/terms). You may opt out of data collection at any point from the Settings panel.
+
+## How do I sign in with a GCP project? [link](https://antigravity.google/\#how-do-i-sign-in-with-a-gcp-project)
+
+Follow the steps in the [Enterprise Page](https://antigravity.google/docs/enterprise) to learn how to sign in with GCP.
+
+## How do I get support? [link](https://antigravity.google/\#how-do-i-get-support)
+
+Check out the communities on our [Support page](https://antigravity.google/support).
+
+## What are the model rate limits? [link](https://antigravity.google/\#what-are-the-model-rate-limits)
+
+Please see more details in the docs on [Plans](https://antigravity.google/docs/plans).
+
+## Why can’t I use third party software (e.g. Claude Code, OpenClaw, OpenCode) with my Antigravity login? [link](https://antigravity.google/\#why-cant-i-use-third-party-software-eg-claude-code-openclaw-opencode-with-my-antigravity-login)
+
+Using third party software, tools, or services to access Antigravity is a violation of our [Terms of Service](https://antigravity.google/terms), and severely degrades the experience for legitimate product users. Such actions may be grounds for suspension or termination of your account. If you would like to use a third party coding agent with Gemini, we recommend using a Vertex or AI Studio API key.
+
+## Does Google Antigravity currently support worktrees? [link](https://antigravity.google/\#does-google-antigravity-currently-support-worktrees)
+
+Yes, you can use worktrees in Antigravity 2.0.
+
+## What happens when my computer goes to sleep? [link](https://antigravity.google/\#what-happens-when-my-computer-goes-to-sleep)
+
+If an agent is running, Antigravity will prevent your computer from sleeping.
+
+[Plans](https://antigravity.google/docs/plans)
+
+On this Page
+
+- FAQ
+
+- Why can I not authenticate into Google Antigravity?
+
+- Why is my age unverified?
+
+- What is Google Antigravity’s geographical availability?
+
+- Why am I ineligible for a Google One AI plan?
+
+- What is Google Antigravity’s stance on data collection?
+
+- How do I sign in with a GCP project?
+
+- How do I get support?
+
+- What are the model rate limits?
+
+- Why can’t I use third party software (e.g. Claude Code, OpenClaw, OpenCode) with my Antigravity login?
+
+- Does Google Antigravity currently support worktrees?
+
+- What happens when my computer goes to sleep?

--- a/docs/docs-home.md
+++ b/docs/docs-home.md
@@ -1,0 +1,116 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Home
+
+# Welcome to Google Antigravity [link](https://antigravity.google/\#welcome-to-google-antigravity)
+
+## Choose Your Surface [link](https://antigravity.google/\#choose-your-surface)
+
+Google Antigravity offers multiple product surfaces tailored to your specific development workflow. Select the interface that best fits your needs:
+
+### Antigravity 2.0 [link](https://antigravity.google/\#antigravity-20)
+
+Your standalone desktop command center for your agents. Start agents inside Projects, work across multiple workspaces and worktrees, and orchestrate complex tasks using parallel local subagents.
+
+- **Key Features**: Asynchronous task management, Scheduled Tasks (Cron sidecars), and voice transcription.
+- **Get Started**: Read the [Getting Started Guide](https://antigravity.google/docs/getting-started)
+
+### Antigravity CLI [link](https://antigravity.google/\#antigravity-cli)
+
+The lightweight, keyboard-centric Terminal User Interface surface. It brings the same core agentic capabilities as the desktop app directly to your terminal workflow, making it perfect for fast interactions and SSH sessions.
+
+- **Key Features**: High-speed prompt shortcuts, custom keybindings, and parallel subagent management.
+- **Get Started**: Explore the [CLI Quick Overview](https://antigravity.google/docs/cli/overview)
+
+### Antigravity SDK [link](https://antigravity.google/\#antigravity-sdk)
+
+A programmatic Python framework for researchers and developers who want complete control over their agent deployments. Custom build an agent, register custom tools, and implement lifecycle hooks, all on top of the Antigravity Harness.
+
+- **Key Features**: Declarative safety policies, inspect/decide/transform hooks, and programmatic subagent spawning.
+- **Get Started**: Review the [SDK Overview](https://antigravity.google/docs/sdk/overview)
+
+### Antigravity IDE [link](https://antigravity.google/\#antigravity-ide)
+
+The fully-featured, AI-powered developer environment. Standardize your daily coding with powerful tightly integrated coding agents, deep context awareness, tools like MCP and skills, and more.
+
+- **Get Started**: Read the [IDE Getting Started Guide](https://antigravity.google/docs/ide/getting-started)
+
+### Core Agent Capabilities [link](https://antigravity.google/\#core-agent-capabilities)
+
+Every Antigravity surface runs on a shared, highly-optimized agent harness co-trained with Gemini models:
+
+- **Gemini 3.5 Flash**: Powering all local agents with SOTA speed, reasoning, and context window capacity.
+- **[Asynchronous Subagents](https://antigravity.google/docs/subagents)**: Allows the main agent to delegate parallel background tasks to concurrent subagents without blocking your flow.
+- **[Visual Artifacts](https://antigravity.google/docs/artifacts)**: Track and verify agent output (plans, code diffs, browser recordings) with high-fidelity visual reports, keeping you informed every step of the way.
+- **[Security by Design](https://antigravity.google/docs/permissions)**: Secure local execution via safe defaults, local proxying, and granular tool approval gates.
+- **[Google Integrations](https://antigravity.google/docs/build-with-google)**: We partner with product teams across Google to provide curated bundles of skills, MCP servers, and extensions that make building on Google platforms frictionless.
+- **Android**: Editor extension, CLI integrations, and Android developer skills.
+- **Firebase**: Curated skills for Firebase Firestore, Cloud Functions, and more.
+- **Web**: Chrome and Web MCP servers for autonomous browser research.
+- **Science**: Specialized DeepMind biology and chemistry skills to accelerate scientific workflows.
+- **AGY SDK**: Skills that optimize your agent’s ability to use the Antigravity SDK to build custom AI agents tailored to your workflow.
+
+[Overview](https://antigravity.google/docs/overview)
+
+On this Page
+
+- Welcome to Google Antigravity
+
+- Choose Your Surface

--- a/docs/docs-plans.md
+++ b/docs/docs-plans.md
@@ -1,0 +1,126 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Plans
+
+# Plans [link](https://antigravity.google/\#plans)
+
+Google Antigravity is available with [terms](https://antigravity.google/terms) to individual accounts derived from Google's terms of service, and available to teams under Google Cloud terms through the Gemini Enterprise Agent Platform. To learn more, see [Enterprise Get Started](https://antigravity.google/docs/enterprise).
+
+Rate limits and model availability differs based on usage of [Google AI](https://one.google.com/about/google-ai-plans/) plans. See [Models](https://antigravity.google/docs/models) for a breakdown of model availability.
+
+## Baseline Quota [link](https://antigravity.google/\#baseline-quota)
+
+All plans receive a baseline of:
+
+- Use of Gemini models including Gemini 3.1 Pro, Gemini 3.5 Flash, and other offered Gemini Enterprise Agent Platform models as the core agent model
+- Unlimited Tab completions
+- Access to all product features, such as the Scheduled Tasks and the CLI
+
+Users on Google AI Ultra receive:
+
+- The highest, most generous quota, refreshed every five hours
+- Highest weekly rate limits
+- Access to third-party models
+
+Users on Google AI Pro receive:
+
+- High, generous quota, refreshed every five hours until weekly limit reached
+- Higher weekly rate limit
+
+Users not on AI Pro and Ultra plans receive:
+
+- Meaningful quota, refreshed weekly
+- Weekly rate limit
+
+The baseline rate limits are primarily determined to the degree we have capacity, and exist to prevent abuse. Under the hood, the rate limits are correlated with the amount of work done by the agent, which can differ from prompt to prompt. Thus, you may get many more prompts if your tasks are more straightforward and the agent can complete the work quickly, and the opposite is also true.
+
+Usage limits for this service are subject to modification. These adjustments may be necessary to manage system capacity and maintain service stability.
+
+## Overages [link](https://antigravity.google/\#overages)
+
+Users on Google AI Pro or Ultra plans can utilize [purchased AI credits](http://one.google.com/ai/credits) (or any one-time promotional credits) for additional overage usage above the baseline provided quota. AI credits are consumed at standard Gemini Enterprise Agent Platform consumption pricing.
+
+Usage of credits once the baseline quota is exhausted for any particular model is controlled by the "AI Credit Overages" user setting, which can be set to the following:
+
+- Never: Never use AI credits automatically, wait until the baseline quota refreshes before using this model further
+- Always: Always use AI credits when the baseline quota is exhausted (will switch back automatically to using the baseline quota once the refresh hits)
+
+Baseline quota usage across models can be viewed in the settings page.
+
+## Other [link](https://antigravity.google/\#other)
+
+There is currently no support for:
+
+- Bring-your-own-key or bring-your-own-endpoint for additional rate limits
+- Organizational tiers via contract
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+On this Page
+
+- Plans
+
+- Baseline Quota
+
+- Overages
+
+- Other

--- a/docs/docs-sdk-overview.md
+++ b/docs/docs-sdk-overview.md
@@ -1,0 +1,160 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Home](https://antigravity.google/docs/home)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://antigravity.google/docs/enterprise)
+
+[Plans](https://antigravity.google/docs/plans)
+
+[FAQ](https://antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity SDK
+>- Overview + Quick Start
+
+# Google Antigravity SDK [link](https://antigravity.google/\#google-antigravity-sdk)
+
+The Antigravity SDK is a programmatic Python framework designed to build, test, and run autonomous AI agents. It extends the same core agent harness that powers the Antigravity CLI and Antigravity 2.0, allowing you to integrate advanced agentic capabilities directly into your own applications and workflows.
+
+The SDK decouples your agent's logic from where it runs, allowing you to focus on what the agent does; the SDK handles how and where it executes.
+
+## Quick Start [link](https://antigravity.google/\#quick-start)
+
+Install the SDK using pip:
+
+bash
+
+content\_copy
+
+```
+            pip install google-antigravity
+
+```
+
+### Hello World Example [link](https://antigravity.google/\#hello-world-example)
+
+A functional agent that can interact with your local environment in under 15 lines of Python:
+
+python
+
+content\_copy
+
+```
+            import asyncio
+from google.antigravity import Agent, LocalAgentConfig
+
+async def main():
+    config = LocalAgentConfig()
+    async with Agent(config) as agent:
+        response = await agent.chat("What files are in the current directory?")
+        print(await response.text())
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+```
+
+## Core Pillars [link](https://antigravity.google/\#core-pillars)
+
+**1\. Governed Extensibility (Tools)** Every agent starts with a built-in toolset (file I/O, code editing, shell execution, directory search) and can be extended using four types of tools under a unified execution pipeline:
+
+- **Built-in Tools:** Core file and system manipulation capabilities.
+- **Custom Python Functions:** Register any Python callable as an agent tool.
+- **MCP Servers:** Connect any Model Context Protocol (MCP) server (stdio, SSE, or HTTP). See the [MCP Documentation](https://antigravity.google/docs/mcp).
+- **Agent Skills:** Load reusable packages of instructions and tools.
+
+**2\. Declarative Safety Policies** Configure agent permissions using a declarative "deny by default" policy system to control when and how tools are executed:
+
+python
+
+content\_copy
+
+```
+            from google.antigravity.hooks.policy import deny, allow, ask_user
+
+policies = [\
+    deny("*"),                                         # Block all tools by default\
+    allow("view_file"),                                # Allow reading files silently\
+    ask_user("run_command", handler=my_handler),       # Require human approval for shell execution\
+]
+
+```
+
+**3\. Lifecycle Hooks** Gain granular control over agent execution with three categories of hooks across nine concrete lifecycle points (e.g., session start, pre/post turn, pre/post tool call):
+
+- **Inspect** (Read-Only, Non-Blocking): For logging, audit trails, and metrics.
+- **Decide** (Read-Only, Blocking): For custom approval/denial logic (policies).
+- **Transform** (Modifying, Blocking): For sanitizing data in transit or recovering from tool errors.
+
+\-\-\-
+
+### Key Capabilities [link](https://antigravity.google/\#key-capabilities)
+
+- **Streaming:** Access live model reasoning and output chunks as they are generated.
+- **Multimodal Input:** Pass images, PDFs, audio, and video natively using `from_file()`.
+- **Sub-agents:** Spawn child agents with independent tools and contexts to build multi-agent teams.
+- **Structured Output:** Define schemas using Pydantic models to return validated, typed data directly.
+- **Human-in-the-Loop:** Pause execution to ask structured questions and branch based on user input.
+- **Observability:** Track per-turn and cumulative token usage and access thinking traces.
+
+To use the SDK more easily within Antigravity 2.0, use the Antigravity SDK Skill. To learn more about the Antigravity SDK and see more examples of how to use it, visit [**the GitHub repository**](https://github.com/google-antigravity/antigravity-sdk-python)
+
+[CLI Reference](https://antigravity.google/docs/cli/reference)
+
+[MCP](https://antigravity.google/docs/mcp)
+
+On this Page
+
+- Google Antigravity SDK
+
+- Quick Start
+
+- Core Pillars

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,0 +1,140 @@
+[Google Antigravity](https://www.antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://www.antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://www.antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://www.antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://www.antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://www.antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://www.antigravity.google/use-cases)
+
+[Enterprise](https://www.antigravity.google/use-cases/enterprise) [Frontend](https://www.antigravity.google/use-cases/frontend) [Fullstack](https://www.antigravity.google/use-cases/fullstack) [Science](https://www.antigravity.google/use-cases/science) [Marketer](https://www.antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://www.antigravity.google/docs) [Changelog](https://www.antigravity.google/changelog) [Support](https://www.antigravity.google/support) [Press](https://www.antigravity.google/press) [Releases](https://www.antigravity.google/releases)
+
+[Home](https://www.antigravity.google/docs/home)
+
+Antigravity 2.0 expand\_more
+
+[Overview](https://www.antigravity.google/docs/overview)
+
+[Getting Started](https://www.antigravity.google/docs/getting-started)
+
+[Build with Google](https://www.antigravity.google/docs/build-with-google)
+
+[Feature Overview](https://www.antigravity.google/docs/features)
+
+[Models](https://www.antigravity.google/docs/models)
+
+[Projects](https://www.antigravity.google/docs/projects)
+
+Settings chevron\_right
+
+Customizations chevron\_right
+
+Agent Capabilities chevron\_right
+
+Artifacts chevron\_right
+
+Antigravity CLI chevron\_right
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](https://www.antigravity.google/docs/enterprise)
+
+[Plans](https://www.antigravity.google/docs/plans)
+
+[FAQ](https://www.antigravity.google/docs/faq)
+
+- side\_navigation
+- Antigravity 2.0
+>- Getting Started
+
+# Getting Started with Antigravity 2.0 [link](https://www.antigravity.google/\#getting-started-with-antigravity-20)
+
+### Download [link](https://www.antigravity.google/\#download)
+
+Visit [antigravity.google/download](https://antigravity.google/download) to download Google Antigravity 2.0.
+
+- **macOS**: macOS versions with Apple security update support. This is typically the current and two previous versions. Min Version 12 (Monterey), X86 is not supported.
+- **Windows**: Windows 10 (64 bit)
+- **Linux**: glibc >= 2.28, glibcxx >= 3.4.25 (e.g. Ubuntu 20, Debian 10, Fedora 36, RHEL 8)
+
+### Installation [link](https://www.antigravity.google/\#installation)
+
+You may get a notification asking whether you want to “Keep Both” or “Replace” Antigravity, select “Replace.” You will be prompted to re-install the IDE during installation, should you choose to. If you do not install it now and would like to re-download it later, you can do so [here](https://www.antigravity.google/download).
+
+### Creating a Project [link](https://www.antigravity.google/\#creating-a-project)
+
+Agents work within Projects, which define the boundaries of the folders and repositories they can access.
+
+1. Click the **folder with a "+" icon** in the **left sidebar**.
+2. Click on **"New Project"**.
+3. Click **Add Folder** to associate one or more local folders or Git repositories. Adding multiple folders provides your agent with full cross-repository context.
+4. Click **Create**.
+5. _(Optional)_ Configure your Project's settings. Each Project maintains its own isolated settings and security policies that the agent respects.
+
+### Starting an Agent [link](https://www.antigravity.google/\#starting-an-agent)
+
+Once your Project is created, you can spawn an agent to start working on tasks.
+
+1. Type your goal or instruction in the chat input (e.g., "Help me add a new feature") and press **Enter**.
+2. Choose a **Mode** in the setup modal to boot up your agent:
+
+- **Local Mode**: The agent operates directly in your active folders.
+- **New Worktree Mode**: The agent operates in an isolated Git worktree.
+
+### Basic Navigation [link](https://www.antigravity.google/\#basic-navigation)
+
+| Action | macOS | Windows / Linux |
+| --- | --- | --- |
+| **Open Conversation Picker** | `⌘K` | `Ctrl + K` |
+| **Open File Search** | `⌘P` | `Ctrl + P` |
+| **Focus Input** | `⌘L` | `Ctrl + L` |
+| **New Conversation** | `⌘N` | `Ctrl + N` |
+| **Next/Previous Conversation** | `⌥ Up / Down` | `Alt + Up / Down` |
+
+### Slash Commands [link](https://www.antigravity.google/\#slash-commands)
+
+- `/goal`: Run until the specified task is completely finished, not asking for intermediate input from the user.
+- `/grill-me`: Before starting to implement, ask questions back to align on the specific details of the plan.
+- `/schedule`: Run an instruction as a one-time timer in the future or on some recurring schedule (via Scheduled Tasks)
+- `/browser`: We heard the feedback that the agents were still not capable enough to determine exactly when to be using the browser. So for now, we’ve made it such that an explicit slash command controls these behaviors. When used, the agent diligently uses the browser primitives. This requires both Google Chrome and the user to provide permission in Google Chrome to start a debugging session.
+
+[Overview](https://www.antigravity.google/docs/overview)
+
+[Build with Google](https://www.antigravity.google/docs/build-with-google)
+
+On this Page
+
+- Getting Started with Antigravity 2.0

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,239 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](product.md)
+
+Products
+
+[antigravity Antigravity 2.0](product-antigravity-2.md) [terminal Antigravity CLI](product-antigravity-cli.md) [code Antigravity IDE](product-antigravity-ide.md) [sdk Antigravity SDK](product.md/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](use-cases.md)
+
+[Enterprise](use-cases.md/enterprise) [Frontend](use-cases-frontend.md) [Fullstack](use-cases.md/fullstack) [Science](use-cases-science.md) [Marketer](use-cases.md/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](docs.md) [Changelog](changelog.md) [Support](support.md) [Press](press.md) [Releases](releases.md)
+
+[Home](docs-home.md)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](docs.md/cli/overview)
+
+[Getting Started](docs-cli-getting-started.md)
+
+[Installation & Auth](docs.md/cli/install)
+
+[Tutorial](docs-cli-tutorial.md)
+
+[Using AGY CLI](docs.md/cli/using)
+
+[Features](docs.md/cli/features)
+
+[Gemini Migration](docs-cli-gcli-migration.md)
+
+[Prompting](docs.md/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](docs.md/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](docs-cli-projects.md)
+
+Settings chevron\_right
+
+[AI Credits](docs.md/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](docs.md/cli/best-practices)
+
+[Troubleshooting](docs.md/cli/troubleshooting)
+
+[Reference](docs.md/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](docs.md/enterprise)
+
+[Plans](docs.md/plans)
+
+[FAQ](docs.md/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Features
+
+# Antigravity CLI Features [link](\.md#antigravity-cli-features)
+
+### Plugins [link](\.md#plugins)
+
+**How Plugins Work** Plugins are namespaced bundles that can contain skills, agents, rules, MCP servers, and hooks as a single deployable unit.
+
+When you install a plugin, the CLI stages the files in your home directory under `~/.gemini/antigravity-cli/plugins/<plugin_name>/`. The Antigravity Agent automatically discovers and loads these staged customizations.
+
+content\_copy
+
+```
+            ~/.gemini/antigravity-cli/
+├── plugins/
+│   └── <plugin_name>/
+│       ├── plugin.json         # Required marker file
+│       ├── mcp_config.json     # Optional MCP server definitions
+│       ├── hooks.json          # Optional event hooks definition
+│       ├── skills/             # Optional skills
+│       ├── agents/             # Optional subagents
+│       └── rules/              # Optional rules
+└── import_manifest.json        # Tracking manifest
+
+```
+
+**Accessing Plugin Components** Once staged and loaded, you can interact with the plugin components inside the CLI using slash commands.
+
+### Terminal Sandbox [link](\.md#terminal-sandbox)
+
+The Terminal Sandbox is a lightweight security isolation mechanism that protects your host system from potentially destructive file manipulations or unauthorized outbound network requests when the agent executes local shell commands.
+
+Rather than running heavy virtual machines or containers, the CLI leverages native operating system features (`nsjail` on Linux, `sandbox-exec` on macOS, and `AppContainer` on Windows) to enforce strict containment boundaries with zero startup overhead.
+
+**Configuration** You can configure the sandbox behavior in your `settings.json` file (located at `~/.gemini/antigravity-cli/settings.json`):
+
+json
+
+content\_copy
+
+```
+            {
+  "enableTerminalSandbox": true
+}
+
+```
+
+- **`enableTerminalSandbox`** (boolean, default: `false`): Enables general execution containment barriers on all local agent processes.
+
+**Interactive Approvals** When the agent proposes a terminal command that requires your confirmation, the CLI prompt adapts dynamically based on your settings:
+
+- **When the Sandbox is Enabled**: The confirmation prompt will include a specific option to **Yes, and run without sandbox restrictions** if you need to temporarily bypass the containment boundary for a single trusted command.
+- **When the Sandbox is Disabled**: The prompt will include an option to **Yes, and run in sandbox** if you want to force a specific, potentially risky command to execute within the safety boundary.
+
+### CLI Slash Commands Reference [link](\.md#cli-slash-commands-reference)
+
+The Antigravity CLI supports a variety of slash commands typed directly into the prompt box to manage conversations, configure settings, and inspect agent capabilities.
+
+### Core Slash Commands [link](\.md#core-slash-commands)
+
+| Command | Category | Purpose |
+| --- | --- | --- |
+| **`/resume`** _(alias `/switch`)_ | Conversation | Open the conversation picker to resume or switch sessions. |
+| **`/rewind`** _(alias `/undo`)_ | Conversation | Roll back conversation history to a previous checkpoint. |
+| **`/rename <name>`** | Conversation | Rename the active conversation thread for easier tracking. |
+| **`/permissions`** | Configuration | Select agent autonomy level (`request-review`, `always-proceed`, or `strict`). |
+| **`/model`** | Configuration | Select the default reasoning model (persists across sessions). |
+| **`/keybindings`** | Configuration | Open the interactive keyboard shortcut editor. |
+| **`/statusline`** | Configuration | Customize real-time indicators displayed in the CLI status bar. |
+| **`/tasks`** | Tools & Monitoring | Monitor, view logs for, or terminate active background tasks. |
+| **`/skills`** | Tools & Monitoring | Browse local and global encapsulated agent workflows. |
+| **`/mcp`** | Tools & Monitoring | Open the panel to configure and manage Model Context Protocol servers. |
+| **`/open <path>`** | Utility | Immediately open a file in your preferred external editor. |
+| **`/diff`** | Utility | Open the [interactive diff viewer](docs.md/cli/commands/diff) to review changes and steer the agent. |
+| **`/usage`** | Utility | Open the inline interactive help manual inside the terminal. |
+| **`/logout`** | Account | Log out of your Google session and clear cached credentials. |
+
+### Advanced Customization via \`settings.json\` [link](\.md#advanced-customization-via-settingsjson)
+
+For power users, several slash commands support deep customization via your `~/.gemini/antigravity-cli/settings.json` configuration:
+
+- **Fine-Grained Permissions**: Instead of global levels, define specific allowed/denied commands:
+
+content\_copy
+
+```
+                "permissions": {
+      "allow": ["command(git)", "command(npm test)"],
+      "deny": ["command(rm -rf)"]
+    }
+
+```
+
+- **Custom Status Line & Window Titles**: You can pipe live agent metadata (JSON format containing CWD, active model, token usage, state, etc.) directly into your own custom shell scripts to generate dynamic status bars or terminal window titles.
+
+### Subagents in Antigravity CLI [link](\.md#subagents-in-antigravity-cli)
+
+Antigravity CLI features an asynchronous subagents framework that allows the main agent to delegate parallel work, perform background research, and run system tests without blocking your active conversation.
+
+**What are Subagents?** Subagents are independent, concurrent agent sessions designed to tackle specific background tasks in parallel with the main conversation.
+
+- **Purpose**: The main agent automatically spawns subagents to perform background operations such as looking up documentation, running builds, or validating a fix.
+- **Capabilities**: Subagents have full access to tools such as code search, file editing, terminal commands, and web searches to complete their assigned tasks.
+- The main agent decides what tools and permissions subagents get, including whether they can use MCP tools and if they can write files.
+
+### Managing Agents: The \`/agents\` Panel [link](\.md#managing-agents-the-agents-panel)
+
+Antigravity CLI provides an interactive terminal UI to view, manage, and approve actions for running subagents.
+
+- **Access**: Type `/agents` in the prompt to open the subagents panel.
+- **Overview**: The panel shows a list of active and completed subagents, including surface-level details such as their status (running, done, killed, etc.) and the current step they are executing.
+
+info
+
+Selecting a subagent from the panel opens a full-screen detail view. This view shows the entirety of the subagent’s conversation, including its steps, thoughts, and tool execution logs.
+
+**Tool Confirmations & Approvals** When a subagent wants to execute a tool that requires user permissions (such as running a local command or writing a file), it will surface the request. You can manage approvals in two ways:
+
+1. **Detail View Approvals**
+
+The Subagent Detail View features an interaction section containing all pending approvals, where you can selectively approve or deny requests.
+
+lightbulb
+
+**Tip**: Use the keyboard shortcut `ctrl+j` to "teleport" from the main conversation directly to the detailed view of the next subagent waiting for your approval.
+
+1. **Fast Path Alerts**
+
+To keep you in your flow, Antigravity CLI displays a Fast Path Alert directly above your prompt box when a subagent requests permission.
+
+lightbulb
+
+**Tip**: You can approve a pending subagent permission instantly using `ctrl+k` without ever having to switch away from the main conversation.
+
+[Using AGY CLI](docs.md/cli/using)
+
+[Migration](docs-cli-gcli-migration.md)
+
+On this Page
+
+- Antigravity CLI Features

--- a/docs/press.md
+++ b/docs/press.md
@@ -1,0 +1,87 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Press Assets
+
+![Icon - Full Color](https://antigravity.google/assets/image/brand/antigravity-icon__full-color.png)
+
+[Download PNG](https://antigravity.google/assets/image/brand/antigravity-icon__full-color.png)
+
+Icon - Full Color
+
+![Icon - One Color](https://antigravity.google/assets/image/brand/antigravity-icon__one-color.png)
+
+[Download PNG](https://antigravity.google/assets/image/brand/antigravity-icon__one-color.png)
+
+Icon - One Color
+
+![Icon - White](https://antigravity.google/assets/image/brand/antigravity-icon__white.png)
+
+[Download PNG](https://antigravity.google/assets/image/brand/antigravity-icon__white.png)
+
+Icon - White
+
+![Lockup - Full Color](https://antigravity.google/assets/image/brand/antigravity_product_lockup_full_color.png)
+
+[Download PNG](https://antigravity.google/assets/image/brand/antigravity_product_lockup_full_color.png)
+
+Lockup - Full Color
+
+![Lockup - Full Color Reverse](https://antigravity.google/assets/image/brand/antigravity_product_lockup_full_color_reverse.png)
+
+[Download PNG](https://antigravity.google/assets/image/brand/antigravity_product_lockup_full_color_reverse.png)
+
+Lockup - Full Color Reverse
+
+![Wordmark - Full Color White Text](https://antigravity.google/assets/image/brand/antigravity_wordmark_horz__full-color-white-text.png)
+
+[Download PNG](https://antigravity.google/assets/image/brand/antigravity_wordmark_horz__full-color-white-text.png)
+
+Wordmark - Full Color White Text
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/product-antigravity-2.md
+++ b/docs/product-antigravity-2.md
@@ -1,0 +1,64 @@
+# Antigravity 2.0
+
+Google Antigravity 2.0 is your dedicated platform to work with agents. Orchestrate multiple autonomous agents working in parallel across independent projects.
+
+[Download](https://antigravity.google/download#antigravity-2)
+
+## Explore the main features
+
+![An Abstracted UI](https://antigravity.google/assets/image/product/hero-middle-gradient.png)
+
+### An Abstracted UI
+
+Your AI agents' central command center, providing a unified platform to launch, monitor, and orchestrate their activities.
+
+![Dynamic Subagents](https://antigravity.google/assets/image/product/subagents.png)
+
+### Dynamic Subagents
+
+Subagents are defined and instantiated dynamically to tackle parallel parts of complex problems, leading to faster and better results.
+
+![Scheduled Tasks](https://antigravity.google/assets/image/product/scheduled.png)
+
+### Scheduled Tasks
+
+Automate routine checks with Scheduled Tasks, simply define a cron schedule and the agents start and run autonomously in the background.
+
+![Artifacts](https://antigravity.google/assets/image/product/artifacts.png)
+
+### Artifacts
+
+Deliverables from the Agent that communicate its progress with you.
+
+![Extend Customization](https://antigravity.google/assets/image/product/skills.jpg)
+
+### Extend Customization
+
+Create or download fully customizable skills to further your agent’s autonomy and transform how you get work done.
+
+folder\_copy
+
+Projects
+
+Group your conversations into Projects, which can span multiple folders and support custom settings and scoped permissions.
+
+transcribe
+
+Live Voice Transcription
+
+Speak your prompts. Powered by the latest Gemini Audio models, real-time transcription converts conversational speech into clearly phrased prompts.
+
+dashboard\_customize
+
+Extend Customization
+
+Define global or workspace-specific Skills, MCPs and JSON Hooks to encourage custom agent behavior.
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Download Google Antigravity for LinuxDownload Google Antigravity for Linux
+
+Download
+
+[Google](https://www.google.com/)
+
+Manage cookies

--- a/docs/product-antigravity-cli.md
+++ b/docs/product-antigravity-cli.md
@@ -1,0 +1,74 @@
+# Antigravity CLI
+
+The terminal-first surface to interact with Antigravity agents. Stay in your flow without context switching.
+
+[Install](https://antigravity.google/download#antigravity-cli)
+
+![](https://antigravity.google/assets/image/product/antigravity-cli/hero.png)
+
+## Explore the main features
+
+### Work in Natural Language
+
+Edit, orchestrate, and build all in natural language. Tell your agents what you need, and they’ll work on getting it done.
+
+![Subagents functionalities](https://antigravity.google/assets/image/product/antigravity-cli/subagents-functionality.jpg)
+
+### Subagents functionalities
+
+Have multiple agents working in parallel, so larger tasks get tackled faster.
+
+ads\_click
+
+Snappy Experience
+
+A minimal resource footprint designed for speed; the most lightweight way to invoke, monitor, and interact with Antigravity agents.
+
+format\_list\_bulleted\_spark
+
+Subagents
+
+Delegate background tasks to concurrent agent sessions. Type /agents to open the panel and monitor status, and use ctrl+k to approve tools instantly.
+
+subtitles\_gear
+
+Highly configurable
+
+Navigate your entire workflow via standard terminal shortcuts: adjust permissions, themes, and preferences via /config and type /keybindings to customize every shortcut.
+
+article\_shortcut
+
+Slash Commands
+
+Access plugins, MCP, skills, and hooks configurations instantly via slash commands, quickly enhancing your workflow.
+
+terminal
+
+Where you are
+
+Perfect for builders who live in the terminal.
+
+## Get Started
+
+![Terminal demo mockup](https://antigravity.google/assets/image/product/antigravity-cli/demo.gif)
+
+## Launch the TUI
+
+Open a fresh terminal window, navigate to your target project directory, and execute the launcher command to start your first session.
+
+## First-Launch Setup
+
+On your first launch, the TUI will walk you through a brief interactive setup to configure your color scheme, rendering mode, and workspace trust.
+
+## Learn More
+
+Check out the [Getting Started Guide](https://antigravity.google/docs/cli/getting-started) for details on advanced setup, proxy configuration, and writing your first prompt.
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Install Google Antigravity CLIInstall Google Antigravity CLI
+
+[Install](https://antigravity.google/download#antigravity-cli)
+
+[Google](https://www.google.com/)
+
+Manage cookies

--- a/docs/product-antigravity-ide.md
+++ b/docs/product-antigravity-ide.md
@@ -1,0 +1,62 @@
+# Antigravity IDE
+
+Google Antigravity's Editor view offers tab autocompletion, natural language code commands, and a configurable, and context-aware configurable agent.
+
+[Download](https://antigravity.google/download#antigravity-ide)
+
+close
+
+play\_arrowPlay video
+
+play\_arrow
+
+## Explore the main features
+
+### Editor
+
+Fully-featured AI-powered IDE with Tab, Command, Agents, and more.
+
+![Agent](https://antigravity.google/assets/image/product/agent.jpg)
+
+### Agent
+
+Able to autonomously operate across your editor, terminal, and browser.
+
+![Artifacts](https://antigravity.google/assets/image/product/artifacts.jpg)
+
+### Artifacts
+
+Manage higher-level tasks for the Agent, not individual tool calls.
+
+![User Feedback](https://antigravity.google/assets/image/product/user-feedback.jpg)
+
+### User Feedback
+
+Leave comments and feedback on any Artifact to better guide the Agent.
+
+code\_blocks
+
+The complete code editor surface for direct file modification
+
+Introducing a new agent-first Agent Manager experience. This innovative approach enables agents to operate seamlessly across all surfaces, including your browser, so they can tackle more complex and long-running tasks.
+
+auto\_tab\_group
+
+Rich, visual feedback and artifact review right in your editor
+
+Gain a complete understanding of agentic operations at the task level, supported by the essential artifacts and verification outcomes, fostering confidence in the agent's actions.
+
+arrow\_and\_edge
+
+An agent that works as an active, integrated development partner
+
+Intuitively provide feedback across every surface and Artifact to steer the agent to your desired outcomes.
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Download Google Antigravity for LinuxDownload Google Antigravity for Linux
+
+Download
+
+[Google](https://www.google.com/)
+
+Manage cookies

--- a/docs/product-antigravity-sdk.md
+++ b/docs/product-antigravity-sdk.md
@@ -1,0 +1,80 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Antigravity SDK
+
+Build AI agents that autonomously read files, run commands, edit code, and more. The Agent SDK gives you the same tools, agent loop, and context management that power Google Antigravity, programmable in Python.
+
+[Download](https://github.com/google-antigravity/antigravity-sdk-python)
+
+bash
+
+content\_copy
+
+```
+            pip install google-antigravity
+
+```
+
+## Important
+
+The Google Antigravity SDK relies on a compiled runtime binary that is included in the platform-specific wheels published to [PyPI](https://pypi.org/project/google-antigravity/). Cloning this repository alone is not sufficient to run the SDK. Always install from PyPI with pip install google-antigravity to obtain the binary.
+
+## Unified Tool Experience
+
+Layer custom Python callables, Model Context Protocol (MCP) servers, and reusable agent skills over our built-in filesystem and terminal tools under a single pipeline.
+
+## Focus on Customizing
+
+The SDK abstracts away the complex machinery of running an AI agent—including state management, tool execution, and backend communication—allowing developers to focus on the agent's behavior rather than infrastructure.
+
+## Multimodal Ingestion
+
+Pass rich multimedia file attachments (images, videos, audio, and documents) to the agent alongside textual instruction prompt lists. You can attach assets directly using content classes (perfect for in-memory bytes) or conveniently from a filesystem path (which automatically resolves types and guesses MIME formats).
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,208 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Agents that help you achieve liftoff
+
+A
+
+g
+
+e
+
+n
+
+t
+
+s
+
+t
+
+h
+
+a
+
+t
+
+h
+
+e
+
+l
+
+p
+
+y
+
+o
+
+u
+
+a
+
+c
+
+h
+
+i
+
+e
+
+v
+
+e
+
+l
+
+i
+
+f
+
+t
+
+o
+
+f
+
+f
+
+[Download](https://antigravity.google/download)
+
+agent\_mode
+
+Agent-first
+
+The agent-first surface built to orchestrate multiple subagents across all your environments. Run complex, long-running workflows in the background while other agents handle everything from research to implementation to testing.
+
+deployed\_code
+
+A more natural abstraction
+
+Gain a complete understanding of agentic operations at the task level, supported by the essential artifacts and verification outcomes, fostering confidence in the agent's actions.
+
+automatic\_cluster
+
+Guidance to go from 90% to 100%
+
+Intuitively provide feedback across every surface and Artifact to steer the agent to your desired outcomes.
+
+![Antigravity 2.0](https://antigravity.google/assets/image/product/antigravity-2.jpg)
+
+### Antigravity 2.0
+
+Your command center to manage multiple local agents in parallel. Group conversations into Projects, operate across multiple workspaces, and automate routine tasks with scheduled messages.
+
+[Download](https://antigravity.google/download) [Learn more](https://antigravity.google/product/antigravity-2)
+
+![Antigravity CLI](https://antigravity.google/assets/image/product/antigravity-cli.png)
+
+### Antigravity CLI
+
+The lightweight, fast, terminal-first surface to work with Antigravity agents. Run autonomous coding agents, execute shell commands directly, and manage background subagents all from your keyboard.
+
+[Download](https://antigravity.google/download) [Learn more](https://antigravity.google/product/antigravity-cli)
+
+![Antigravity SDK](https://antigravity.google/assets/image/product/antigravity-sdk.jpg)
+
+### Antigravity SDK
+
+Prototype custom agents leveraging Antigravity’s harness with minimal code. Simple Python scripts to iterate on agentic applications, automate software engineering tasks, and run evaluations on top of the Antigravity agent harness.
+
+[Download](https://antigravity.google/download) [Learn more](https://antigravity.google/product/antigravity-sdk)
+
+### Antigravity IDE
+
+The fully-featured, agentic IDE. Complete with the agent manager, artifacts, and a deep understanding of your codebase.
+
+[Download](https://antigravity.google/download) [Learn more](https://antigravity.google/product/antigravity-ide)
+
+## Built for productivity and beyond
+
+See what builders and developers like you have been able to achieve with Google Antigravity.
+
+Auto-playing Pinball Machine
+
+play\_arrow
+
+play\_arrowWatch case
+
+Flight Tracker App
+
+play\_arrow
+
+play\_arrowWatch case
+
+Inverted Pendulum Controller
+
+play\_arrow
+
+play\_arrowWatch case
+
+Collaborative Whiteboard App
+
+play\_arrow
+
+play\_arrowWatch case
+
+We challenged robotics researchers to build an auto-playing pinball machine with Google Antigravity.
+
+We iterated on the design of a flight tracker app using Nano Banana within Google Antigravity.
+
+We challenged robotics researchers to build an inverted pendulum controller with Google Antigravity.
+
+We rapidly added a number of features to a collaborative whiteboard app by orchestrating multiple parallel agents in Google Antigravity.
+
+keyboard\_arrow\_leftkeyboard\_arrow\_right
+
+close
+
+## Download Google Antigravity    for Linux
+
+Download
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,260 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](product.md)
+
+Products
+
+[antigravity Antigravity 2.0](product-antigravity-2.md) [terminal Antigravity CLI](product-antigravity-cli.md) [code Antigravity IDE](product-antigravity-ide.md) [sdk Antigravity SDK](product.md/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](use-cases.md)
+
+[Enterprise](use-cases.md/enterprise) [Frontend](use-cases-frontend.md) [Fullstack](use-cases.md/fullstack) [Science](use-cases-science.md) [Marketer](use-cases.md/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](docs.md) [Changelog](changelog.md) [Support](support.md) [Press](press.md) [Releases](releases.md)
+
+[Home](docs-home.md)
+
+Antigravity 2.0 chevron\_right
+
+Antigravity CLI expand\_more
+
+[Overview](docs.md/cli/overview)
+
+[Getting Started](docs-cli-getting-started.md)
+
+[Installation & Auth](docs.md/cli/install)
+
+[Tutorial](docs-cli-tutorial.md)
+
+[Using AGY CLI](docs.md/cli/using)
+
+[Features](docs.md/cli/features)
+
+[Gemini Migration](docs-cli-gcli-migration.md)
+
+[Prompting](docs.md/cli/prompting)
+
+Artifacts chevron\_right
+
+[Conversations](docs.md/cli/conversations)
+
+Agent Capabilities chevron\_right
+
+[Projects](docs-cli-projects.md)
+
+Settings chevron\_right
+
+[AI Credits](docs.md/cli/credits)
+
+Customizations chevron\_right
+
+Commands chevron\_right
+
+[Best Practices](docs.md/cli/best-practices)
+
+[Troubleshooting](docs.md/cli/troubleshooting)
+
+[Reference](docs.md/cli/reference)
+
+Antigravity SDK chevron\_right
+
+Antigravity IDE chevron\_right
+
+Migration chevron\_right
+
+[Enterprise](docs.md/enterprise)
+
+[Plans](docs.md/plans)
+
+[FAQ](docs.md/faq)
+
+- side\_navigation
+- Antigravity CLI
+>- Reference
+
+# CLI reference [link](\.md#cli-reference)
+
+Scan scannable tables listing all TUI slash commands, default keyboard shortcuts, and JSON configuration parameters.
+
+## Core slash commands [link](\.md#core-slash-commands)
+
+Type `/` inside the prompt box to open the typeahead command selection menu.
+
+| Command | Category | Alias | Execution Purpose |
+| --- | --- | --- | --- |
+| **`/add-dir <path>`** | Utilities | — | Add a directory path to the active workspace. |
+| **[`/agents`](docs.md/cli/commands/agents)** | Tools & Tasks | — | Open the [Agent Manager Panel](docs.md/cli/commands/agents) to switch custom agents and monitor background subagents. |
+| **`/artifact`** | Tools & Tasks | — | Open the Artifact Review Panel. |
+| **`/btw <query>`** | Utilities | — | Ask a side question in the background without interrupting the main conversation. |
+| **`/clear`** | Utilities | `/new` | Clear the terminal and reset active conversation contexts. |
+| **`/config`** | Configurations | `/settings` | Open the interactive Settings Editor Overlay. |
+| **`/context`** | Utilities | — | Open the context usage visualization panel. |
+| **`/copy`** | Utilities | — | Copy the last agent response to the system clipboard. |
+| **[`/credits`](docs-cli-commands-credits.md)** | Account | — | View remaining G1 credits and purchase links. |
+| **[`/diff`](docs.md/cli/commands/diff)** | Utilities | — | Open the [Interactive Diff Viewer](docs.md/cli/commands/diff) to view changes, turns, and commits. |
+| **`/exit`** | Core | `/quit` | Close the TUI session and restore your host shell. |
+| **`/fast`** | Configurations | — | Enable fast mode (bypass reasoning plans) for quick actions. |
+| **`/feedback`** | Utilities | — | Open the feedback submission panel. |
+| **`/fork`** | Conversations | `/branch` | Clone the current conversation thread into a new parallel session. |
+| **`/help`** | Utilities | — | Open the help panel showing commands and shortcuts. |
+| **`/hooks`** | Tools & Tasks | — | Browse active pre-flight/post-format script hooks. |
+| **`/keybindings`** | Configurations | — | Open the interactive Keyboard Shortcut Editor. |
+| **`/logout`** | Account | — | Disconnect your profile and purge authentication tokens from the secure keyring. |
+| **`/mcp`** | Tools & Tasks | — | Open the Model Context Protocol (MCP) server manager. |
+| **`/model`** | Configurations | — | Choose your preferred reasoning model (persists across sessions). |
+| **`/open <path>`** | Utilities | — | Force the path to open inside your default system editor. |
+| **[`/permissions`](docs.md/cli/commands/permissions)** | Configurations | — | Open the interactive tool permissions manager panel. |
+| **`/planning`** | Configurations | — | Enable multi-turn plan generation mode for complex engineering tasks. |
+| **`/rename <name>`** | Conversations | — | Rename the current session thread. |
+| **[`/resume`](docs-cli-commands-resume.md)** | Conversations | `/switch`, `/conversation` | Open the [conversation picker overlay](docs-cli-commands-resume.md) to select and load previous threads. |
+| **`/rewind`** | Conversations | `/undo` | Roll back your conversation history to a previous message. |
+| **`/skills`** | Tools & Tasks | — | Browse loaded local and global Agent Skills. |
+| **[`/statusline`](docs.md/cli/commands/statusline)** | Configurations | — | Open the Status Bar customization overlay. |
+| **`/tasks`** | Tools & Tasks | — | Open the Task Manager Panel to monitor background shell execution logs. |
+| **[`/title`](docs.md/cli/commands/title) \[on/off\]** | Configurations | — | Toggle or set terminal window title updates. |
+| **[`/usage`](docs.md/cli/commands/usage)** | Utilities | `/quota` | Display model quota usage. |
+
+## Default keybindings [link](\.md#default-keybindings)
+
+Keyboard shortcut commands mapping global, prompt, navigation, and approval operations.
+
+### Global controls [link](\.md#global-controls)
+
+These hotkeys are always active regardless of which panel, overlay, or prompt is currently focused.
+
+| Key | TUI Command | Action Behavior |
+| --- | --- | --- |
+| **`Esc`** | `cli.escape` | Closes active panels, halts active streams, or clears empty prompts. |
+| **`Ctrl+C`** | `cli.exit` | Terminates the CLI session (prompts for confirmation if agent is working). |
+| **`Ctrl+D`** | `cli.exit` | Exits the CLI session (only when the prompt box is empty). |
+| **`Ctrl+L`** | `cli.clear_screen` | Refreshes and clears the visual terminal buffer. |
+
+### Prompt focus keys [link](\.md#prompt-focus-keys)
+
+These keys are active when writing instructions inside the prompt box.
+
+| Key | TUI Command | Action Behavior |
+| --- | --- | --- |
+| **`Enter`** | `prompt.submit` | Submits your prompt or active menu selection to the agent. |
+| **`Shift+Enter`** / **`Ctrl+J`** | `prompt.newline` | Inserts a clean newline without submitting. |
+| **`Ctrl+V`** | `prompt.paste` | Pastes graphic media files or clipboard blocks into the prompt. |
+| **`Ctrl+O`** | `prompt.toggle_trajectory` | Expands or collapses detailed tool reasoning outputs. |
+| **`Ctrl+R`** | `prompt.open_review` | Opens the Artifact Review Panel. |
+| **`Ctrl+G`** | `prompt.external_editor` | Launches your default `$EDITOR` shell to compose your prompt. |
+| **`Alt+J`** | `prompt.teleport_agent` | Instantly switches focus to the next subagent awaiting confirmation. |
+| **`Ctrl+K`** | `prompt.fast_approve` | Instantly approves the pending subagent action listed in the status alert. |
+| **`Ctrl+A`** | `prompt.cursor_start` | Moves the prompt insertion cursor to the beginning of the line. |
+| **`Ctrl+E`** | `prompt.cursor_end` | Moves the prompt insertion cursor to the end of the line. |
+| **`Ctrl+Z`** | `prompt.undo_text` | Reverts the last edit. |
+| **`Ctrl+Shift+Z`** | `prompt.redo_text` | Redoes the last undone text operation. |
+| **`Ctrl+D`** | `—` | Forward delete (only when the prompt box is non-empty). |
+
+### Navigation & scrolling [link](\.md#navigation-scrolling)
+
+Used inside select panels, menus, and scrollable text boxes.
+
+| Key | TUI Command | Action Behavior |
+| --- | --- | --- |
+| **`↑`** / **`↓`** | `navigation.up` / `navigation.down` | Scrolls highlighted selections up or down by one item. |
+| **`PgUp`** / **`Shift+↑`** | `navigation.page_up` | Scrolls the active text viewport up by one page block. |
+| **`PgDn`** / **`Shift+↓`** | `navigation.page_down` | Scrolls the active text viewport down by one page block. |
+| **`←`** / **`→`** | `navigation.left` / `navigation.right` | Swaps pages inside multipage structures (like the Session Picker). |
+| **`Tab`** | `navigation.tab` | Confirms the highlighted slash-command autofill option. |
+
+### Tool confirmations [link](\.md#tool-confirmations)
+
+Active during confirmation prompts.
+
+| Key | TUI Command | Action Behavior |
+| --- | --- | --- |
+| **`y`** | `confirm.yes` | Authorizes the proposed tool, command, or active artifact. |
+| **`n`** | `confirm.no` | Rejects the proposed tool, command, or active artifact. |
+| **`A`** | `—` | (Inside Review Panel) Approves all generated artifacts in one action (built-in shortcut). |
+
+## Configuration keys (\`settings.json\`) [link](\.md#configuration-keys-settingsjson)
+
+Primary settings key names, data types, system defaults, and expected parameters.
+
+### Example \`settings.json\` [link](\.md#example-settingsjson)
+
+json
+
+content\_copy
+
+```
+            {
+  "colorScheme": "tokyo night",
+  "altScreenMode": "always",
+  "toolPermission": "request-review",
+  "notifications": true,
+  "enableTerminalSandbox": true
+}
+
+```
+
+| Option Key Name | Value Type | System Default | Parameter Characteristics & Options |
+| --- | --- | --- | --- |
+| **`colorScheme`** | string | `"terminal"` | Color theme: `"light"`, `"solarized light"`, `"colorblind-friendly light"`, `"dark"`, `"solarized dark"`, `"colorblind-friendly dark"`, `"tokyo night"`, or `"terminal"` (inherits native shell colors). |
+| **`altScreenMode`** | string | `"default"` | Screen buffer usage: `"default"` (adaptive inline/altscreen), `"always"` (force alternate screen buffer), or `"never"` (force inline sequential output). |
+| **`toolPermission`** | string | `"request-review"` | Global safety presets: `"request-review"` (prompts for write/bash/web tools), `"proceed-in-sandbox"` (auto-proceed inside sandbox), `"always-proceed"` (never prompts), or `"strict"` (prompts for all non-read tools). |
+| **`artifactReviewPolicy`** | string | `"asks-for-review"` | Code review policy: `"asks-for-review"` (always prompts before writing code), `"agent-decides"` (prompts dynamically), or `"always-proceed"` (never prompts). |
+| **`notifications`** | boolean | `false` | Emits system desktop and terminal bell chime notifications upon task completions. |
+| **`showTips`** | boolean | `true` | Displays helpful agentic tips above the prompt panel during generation turns. |
+| **`showFeedbackSurvey`** | boolean | `true` | Displays periodic quality feedback surveys upon active task completions. |
+| **`editor`** | string | `"auto"` | Target text editor utility: `"auto"` (consults system `$EDITOR`), `"vim"`, `"emacs"`, or custom text labels. |
+| **`allowNonWorkspaceAccess`** | boolean | `false` | Permits the agent's file read and write tools to navigate outside recognized Git/workspace roots. |
+| **`enableTerminalSandbox`** | boolean | `false` | Restricts all local execution commands launched by agents to OS containment rings. |
+| **`useG1Credits`** | boolean | `false` | _External builds only._ Uses personal AI credits for model calls once plan quotas are exhausted. |
+| **`enableTelemetry`** | boolean | `true` | Permits metric collection and crash log streaming to improve tool reliability. |
+| **`verbosity`** | string | `"high"` | Visual verbosity level: `"high"` (renders full thoughts and tool outputs) or `"low"` (displays only minimal visual progress indicators). |
+| **`runningLightSpeed`** | string | `"medium"` | Visual running light progress animation speed: `"fast"`, `"medium"`, `"slow"`, or `"off"`. |
+
+## Next steps [link](\.md#next-steps)
+
+Learn how to safely deploy permission policies, sandboxes, and customize plugins:
+
+- **[Permissions & Sandbox](docs-cli-sandbox.md)**: Enforce command-line containment rules.
+- **[Plugins & Skills](docs.md/cli/plugins)**: Create your own custom skills slash commands.
+- **[Installation & Auth](docs.md/cli/install)**: Update your CLI install.
+
+[Troubleshooting](docs.md/cli/troubleshooting)
+
+[Overview + Quick Start](docs-sdk-overview.md)
+
+On this Page
+
+- CLI reference
+
+- Core slash commands
+
+- Default keybindings
+
+- Configuration keys (\`settings.json\`)
+
+- Next steps

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,161 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Google Antigravity
+
+Releases
+
+G
+
+o
+
+o
+
+g
+
+l
+
+e
+
+A
+
+n
+
+t
+
+i
+
+g
+
+r
+
+a
+
+v
+
+i
+
+t
+
+y
+
+R
+
+e
+
+l
+
+e
+
+a
+
+s
+
+e
+
+s
+
+Download previous Google Antigravity and Antigravity IDE releases. By default, they auto-update to the latest version. To stay on old versions, you will need to set Update: Mode to manual or none in the settings.
+
+[View changelog](https://antigravity.google/changelog)
+
+Antigravity 2.0  Antigravity IDE
+
+Version2.3.1
+
+keyboard\_arrow\_down
+
+#### MacOS
+
+- [downloadmacOS Apple Silicon (.dmg)](https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/darwin-arm/Antigravity.dmg)
+- [downloadmacOS Intel (.dmg)](https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/darwin-x64/Antigravity.dmg)
+
+#### Windows
+
+- [downloadWindows ARM64 (.exe)](https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/windows-arm/Antigravity-arm64.exe)
+- [downloadWindows x64 (.exe)](https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/windows-x64/Antigravity-x64.exe)
+
+#### Linux
+
+- [downloadLinux ARM64 (.tar.gz)](https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/linux-arm/Antigravity.tar.gz)
+- [downloadLinux x64 (.tar.gz)](https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/linux-x64/Antigravity.tar.gz)
+
+Version2.3.0
+
+keyboard\_arrow\_down
+
+Version2.2.1
+
+keyboard\_arrow\_down
+
+Version2.1.4
+
+keyboard\_arrow\_down
+
+Version2.0.11
+
+keyboard\_arrow\_down
+
+Version2.0.10
+
+keyboard\_arrow\_down
+
+Version2.0.6
+
+keyboard\_arrow\_down
+
+Version2.0.1
+
+keyboard\_arrow\_down
+
+Version2.0.0
+
+keyboard\_arrow\_down
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,22 @@
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Find answers in our docs or go to our communityFind answers in our docs or go to our community
+
+View docs
+
+[X\\
+\\
+Join the conversation\\
+\\
+Visit](https://x.com/antigravity) [Youtube\\
+\\
+Watch our videos\\
+\\
+Visit](https://www.youtube.com/@GoogleAntigravity) [LinkedIn\\
+\\
+Stay updated\\
+\\
+Visit](https://www.linkedin.com/company/google-antigravity/)
+
+[Google](https://www.google.com/)
+
+Manage cookies

--- a/docs/use-cases-enterprise.md
+++ b/docs/use-cases-enterprise.md
@@ -1,0 +1,93 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Why enterprise developers choose Google Antigravity
+
+Google Antigravity streamlines workflows by offering tools for parallelization, customization, and efficient knowledge management. This helps eliminate common obstacles and repetitive tasks.
+
+[Explore product](https://antigravity.google/product)
+
+cloud
+
+Enterprise Ready
+
+An AI-powered Editor to experience unparalleled assistance on the most complex tasks.
+
+security
+
+Secure and Compliant
+
+By logging in with your Google Cloud credentials, you inherit Google Cloud's standard data privacy protections and ensure your corporate data is never used for training.
+
+cycle
+
+Production Scale
+
+Co-optimized with Gemini 3.5 for the best results, you can accelerate development cycles and reduce operational costs.
+
+## Relevant Stories
+
+Keeping the Editor  Reducing Context Switching  Building for Trust  Going from 90% to 100%  Idea to Prototype
+
+The Liftoff Series - Building with Editor and Manager modes - YouTube
+
+Tap to unmute
+
+[The Liftoff Series - Building with Editor and Manager modes](https://www.youtube.com/watch?v=3kMuohNwqVY) [Google Antigravity](https://www.youtube.com/channel/UC_eVxIPHFZm7oF_gET0x-8Q)
+
+![thumbnail-image](https://yt3.ggpht.com/DPN3tRSVASpg88kzWPMlCM7_SKmCd7dbUn0JfJQZbpTUhoqYOxs5AXtD3wyjGsAnO2JJzHqO=s68-c-k-c0x00ffffff-no-rj)
+
+Google Antigravity145K subscribers
+
+[Watch on](https://www.youtube.com/watch?v=3kMuohNwqVY)
+
+## Download Google Antigravity   for Linux
+
+Download
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/use-cases-frontend.md
+++ b/docs/use-cases-frontend.md
@@ -1,0 +1,91 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Why frontend developers choose Google Antigravity
+
+Google Antigravity takes browser integration to the next level, helping you build beautiful, performant, and responsive frontends like never before.
+
+[Explore product](https://antigravity.google/product)
+
+![Browser Use](https://antigravity.google/assets/image/use-cases/frontend/browser-use.jpg)
+
+Browser Use
+
+The Agent is able to use Chrome to navigate to pages and interact with them, enabling browser-in-the-loop testing of its own code.
+
+![Visual Artifacts](https://antigravity.google/assets/image/use-cases/frontend/visual-artifacts.jpg)
+
+Visual Artifacts
+
+The Agent is able to take screenshots and videos of its work in the browser so that you can see the results of the work asynchronously.
+
+![Visual Feedback](https://antigravity.google/assets/image/use-cases/frontend/visual-feedback.jpg)
+
+Visual Feedback
+
+You are able to leave visual comments on the visual Artifacts, making it simple to provide specific targeted feedback to the Agent.
+
+## Relevant Stories
+
+Easing Frontend Verification  Integrating Design Iteration  Building for Trust  Going from 90% to 100%
+
+The Liftoff Series - How frontend devs use agents within the browser - YouTube
+
+Tap to unmute
+
+[The Liftoff Series - How frontend devs use agents within the browser](https://www.youtube.com/watch?v=yiHKlPuZ73c) [Google Antigravity](https://www.youtube.com/channel/UC_eVxIPHFZm7oF_gET0x-8Q)
+
+Google Antigravity145K subscribers
+
+[Watch on](https://www.youtube.com/watch?v=yiHKlPuZ73c)
+
+## Download Google Antigravity   for Linux
+
+Download
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/use-cases-fullstack.md
+++ b/docs/use-cases-fullstack.md
@@ -1,0 +1,91 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Why fullstack developers choose Google Antigravity
+
+Google Antigravity elevates your fullstack applications, ensuring unparalleled trust through advanced verification and testing.
+
+[Explore product](https://antigravity.google/product)
+
+![Artifacts and Verification](https://antigravity.google/assets/image/use-cases/fullstack/artifacts-and-verification.jpg)
+
+Artifacts and Verification
+
+Agents prioritize verifying information and interacting with users through artifacts and tasks to build trust in their code.
+
+![Feedback](https://antigravity.google/assets/image/use-cases/fullstack/feedback.jpg)
+
+Feedback
+
+Intuitively provide feedback across every surface and Artifact to guide the Agent from 90% to 100%.
+
+![Manager to Editor handoffs](https://antigravity.google/assets/image/use-cases/fullstack/manager-to-editor-handoffs.jpg)
+
+Manager to Editor handoffs
+
+Seamlessly switch between parallel Agents across workspaces in the Agent Manager view to a synchronous editor experience.
+
+## Relevant Stories
+
+Building for Trust  Going from 90% to 100%  Easing Frontend Verification  Integrating Design Iteration  Keeping the Editor  Reducing Context Switching
+
+The Liftoff Series - Trusting the agents' work through verification - YouTube
+
+Tap to unmute
+
+[The Liftoff Series - Trusting the agents' work through verification](https://www.youtube.com/watch?v=htV29JrMXmA) [Google Antigravity](https://www.youtube.com/channel/UC_eVxIPHFZm7oF_gET0x-8Q)
+
+Google Antigravity145K subscribers
+
+[Watch on](https://www.youtube.com/watch?v=htV29JrMXmA)
+
+## Download Google Antigravity   for Linux
+
+Download
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/use-cases-marketer.md
+++ b/docs/use-cases-marketer.md
@@ -1,0 +1,97 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Why Marketers choose Google Antigravity
+
+[Explore product](https://antigravity.google/product)
+
+close
+
+play\_arrowPlay video
+
+play\_arrow
+
+Google Antigravity removes the bottlenecks of daily work and accelerates execution. Build custom skills, run workflows in parallel, and steer agents with real-time, iterative feedback.
+
+arrow\_and\_edge
+
+Collaborative Steering
+
+Define the report, analysis, or content you need. Let the agent execute while you leave comments to steer the results.
+
+agent\_mode
+
+Parallel Agent Execution
+
+Offload research, sourcing, and drafting to specialized subagents running in parallel to accelerate work.
+
+task\_spark
+
+Automated Scheduled Task and Skills
+
+Deploy scheduled cron agents to run routine tasks like auditing sites, scanning docs for errors, or generating daily briefs. Create custom skills to automate workflows.
+
+## Relevant Stories
+
+Keeping the Editor  Reducing Context Switching  Building for Trust  Going from 90% to 100%  Idea to Prototype
+
+The Liftoff Series - Building with Editor and Manager modes - YouTube
+
+Tap to unmute
+
+[The Liftoff Series - Building with Editor and Manager modes](https://www.youtube.com/watch?v=3kMuohNwqVY) [Google Antigravity](https://www.youtube.com/channel/UC_eVxIPHFZm7oF_gET0x-8Q)
+
+Google Antigravity145K subscribers
+
+[Watch on](https://www.youtube.com/watch?v=3kMuohNwqVY)
+
+## Download Google Antigravity   for Linux
+
+Download
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/use-cases-science.md
+++ b/docs/use-cases-science.md
@@ -1,0 +1,85 @@
+[Google Antigravity](https://antigravity.google/)
+
+Products keyboard\_arrow\_down
+
+Use Cases keyboard\_arrow\_down
+
+Pricing
+
+Blog
+
+Resources keyboard\_arrow\_down
+
+Download download
+
+menu
+
+Products keyboard\_arrow\_down
+
+Explore our next generation products
+
+[See overview](https://antigravity.google/product)
+
+Products
+
+[antigravity Antigravity 2.0](https://antigravity.google/product/antigravity-2) [terminal Antigravity CLI](https://antigravity.google/product/antigravity-cli) [code Antigravity IDE](https://antigravity.google/product/antigravity-ide) [sdk Antigravity SDK](https://antigravity.google/product/antigravity-sdk)
+
+Use Cases keyboard\_arrow\_down
+
+Built for developers in the agent-first era
+
+[See overview](https://antigravity.google/use-cases)
+
+[Enterprise](https://antigravity.google/use-cases/enterprise) [Frontend](https://antigravity.google/use-cases/frontend) [Fullstack](https://antigravity.google/use-cases/fullstack) [Science](https://antigravity.google/use-cases/science) [Marketer](https://antigravity.google/use-cases/marketer)
+
+Pricing  Blog  Resources keyboard\_arrow\_down
+
+Everything you need to stay up-to-date and get help
+
+[Documentation keyboard\_arrow\_right](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Support](https://antigravity.google/support) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+# Why choose Google Antigravity for science
+
+[Explore product](https://antigravity.google/product)
+
+close
+
+play\_arrowPlay video
+
+play\_arrow
+
+Google Antigravity streamlines workflows by offering tools for parallelization, customization, and efficient knowledge management. This helps eliminate common obstacles and repetitive tasks.
+
+[Install Science Skills](https://github.com/google-deepmind/science-skills)
+
+![Verifiable Scientific Artifacts](https://antigravity.google/assets/image/use-cases/science/scientific-artifacts.png)
+
+Verifiable Scientific Artifacts
+
+Build trust with results that are grounded in evidence and legible at each step.
+
+![Specialized Science Skills](https://antigravity.google/assets/image/use-cases/science/science-skills.png)
+
+Specialized Science Skills
+
+Give your agents fluency in the tools, models, and databases that researchers use—from frontier models like AlphaGenome to over 30 major scientific databases including AlphaFold Database UniProt, PubChem, and ChEMBL.
+
+![Accelerating Discovery Workflows](https://antigravity.google/assets/image/use-cases/science/discovery-workflows.png)
+
+Accelerating Discovery Workflows
+
+Accelerate your analysis pipelines—from literature synthesis to wet-lab reagent generation—condensing hours of manual work into minutes.
+
+## Download Google Antigravity   for Linux
+
+Download
+
+Experience liftoff
+
+[Download](https://antigravity.google/download) [Product](https://antigravity.google/product) [Docs](https://antigravity.google/docs) [Changelog](https://antigravity.google/changelog) [Press](https://antigravity.google/press) [Releases](https://antigravity.google/releases)
+
+[Blog](https://antigravity.google/blog) [Pricing](https://antigravity.google/pricing) [Use Cases](https://antigravity.google/use-cases)
+
+[Google](https://www.google.com/)
+
+[About Google](https://about.google/) [Google Products](https://about.google/products/) [Privacy](https://policies.google.com/privacy?hl=en-US) [Terms](https://antigravity.google/terms) Manage cookies

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,128 @@
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Enterprise
+
+E
+
+n
+
+t
+
+e
+
+r
+
+p
+
+r
+
+i
+
+s
+
+e
+
+Antigravity 2.0 comes with a new command center surface for background agents to tackle backlog tasks, perform codebase research, and reduce context switching.
+
+[Explore use case](https://antigravity.google/use-cases/enterprise)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Frontend
+
+F
+
+r
+
+o
+
+n
+
+t
+
+e
+
+n
+
+d
+
+Antigravity's Agents can use browser-in-the-loop iteration and visual feedback to speed up the mindnumbing parts of frontend development, helping you build beautiful, performant, and responsive frontends with ease.
+
+[Explore use case](https://antigravity.google/use-cases/frontend)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Fullstack
+
+F
+
+u
+
+l
+
+l
+
+s
+
+t
+
+a
+
+c
+
+k
+
+Antigravity's Agents place an emphasis on verification, communicating to users via Artifacts and tasks to tackle more complex challenges and build user trust in their code.
+
+[Explore use case](https://antigravity.google/use-cases/fullstack)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Science
+
+S
+
+c
+
+i
+
+e
+
+n
+
+c
+
+e
+
+Antigravity's Agents have fluency in the tools, models, and databases that researchers use—from frontier models like AlphaGenome to over 20 major scientific databases including AlphaFold Database UniProt, PubChem, and ChEMBL.
+
+[Explore use case](https://antigravity.google/use-cases/science)
+
+![](https://antigravity.google/assets/image/antigravity-cursor.png)
+Marketer
+
+M
+
+a
+
+r
+
+k
+
+e
+
+t
+
+e
+
+r
+
+Antigravity removes the bottlenecks of daily work and accelerates execution. Build custom skills, run workflows in parallel, and steer agents with real-time, iterative feedback.
+
+[Explore use case](https://antigravity.google/use-cases/marketer)
+
+- ![](https://antigravity.google/assets/image/icons/use-cases/professional.svg)Enterprise
+- ![](https://antigravity.google/assets/image/icons/use-cases/frontend.svg)Frontend
+- ![](https://antigravity.google/assets/image/icons/use-cases/fullstack.svg)Fullstack
+- ![](https://antigravity.google/assets/image/icons/use-cases/science.svg)Science
+- ![](https://antigravity.google/assets/image/icons/use-cases/product-marketing-manager.svg)Marketer
+
+[Google](https://www.google.com/)
+
+Manage cookies


### PR DESCRIPTION
This PR adds raw markdown versions of the SPA documentation to a new docs/ directory so that headless AI agents can read them natively. It also updates the internal cli.md references to point to these new GitHub-hosted markdown files instead of the SPA.