### PR TITLE
docs: add multi-language README support with verified links (fixes #104)

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -1,0 +1,245 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README-ZH.md">中文</a> | <a href="README-ES.md">Español</a> | <a href="README-FR.md">Français</a> | <a href="README-PT.md">Português</a> | <a href="README-UA.md">Українська</a> | <b>Deutsch</b>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
+
+<h1 align="center">🚀 Antigravity CLI</h1>
+
+<p align="center">
+  <strong>Community-Fork & gehärtete Offline-Version von google-antigravity/antigravity-cli mit automatischer Konfiguration von Statuszeile und Fenstertitel</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.0-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
+
+<p align="center">
+  🤖 <b>KI-Codierungsagent direkt in Ihrem Terminal</b>. Versteht den Kontext Ihrer Codebasis, erstellt und bearbeitet Dateien, führt sichere Befehle in einer Sandbox aus und löst komplexe architektonische Aufgaben mit einem einzigen Prompt.
+</p>
+
+---
+
+## ⚡ Schnellstart
+
+### Sofortige Installation (Offline-first & Zero-dependency)
+Dieser Fork lädt vorkompilierte Binärdateien direkt aus den **GitHub Release Assets** herunter (anstatt von Google-API-Servern). Eine vollständig autonome Offline-Installation wird ebenfalls unterstützt, wenn die erforderlichen Archive zuvor in den Ordner `packages/binaries/` heruntergeladen wurden.
+
+#### 🐧 Linux und 🍎 macOS
+```bash
+# Netzwerkinstallation aus dem Fork-Repository:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# ODER Offline-Installation aus einem lokalen Repository:
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# (Optional: Laden Sie Plattform-Archive nach packages/binaries/ herunter)
+make install
+```
+
+#### 🪟 Windows PowerShell
+```powershell
+# Netzwerkinstallation:
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# ODER Offline-Installation aus einem geklonten Repository:
+.\install.ps1
+```
+
+#### 🪟 Windows CMD
+```cmd
+# Netzwerkinstallation:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# ODER Offline-Installation aus einem geklonten Repository:
+install.cmd
+```
+
+---
+
+## 📋 Hauptfunktionen
+
+> [!NOTE]
+> Im Gegensatz zur Originalversion ist dieser Fork für den stabilen Betrieb in Headless-/SSH-Sitzungen und lokalen Home-Labs angepasst.
+
+*   📂 **Bearbeitung mehrerer Dateien** — Bearbeitet mehrere Dateien gleichzeitig in Ihrem Arbeitsbereich mit vorheriger Bestätigung der Änderungen.
+*   🔒 **Sichere Shell-Befehle** — Führt beliebige Terminalbefehle im integrierten Docker-Container (Sandbox) oder auf dem Hostsystem aus.
+*   🧠 **Mehrstufiges Denken (PAV)** — Erstellt selbstständig einen Plan zur Aufgabenausführung, testet Code und behebt eigene Fehler.
+*   💾 **Persistenter Konversationsverlauf** — Speichert den vollständigen Konversationskontext und den Zustand des Arbeitsbereichs zwischen den Sitzungen.
+*   🔌 **Plugin-System** — Erweitern Sie die Fähigkeiten des Agenten mit benutzerdefinierten *Skills* und MCP-Servern (Model Context Protocol).
+
+---
+
+## ⚙️ Konfiguration
+
+### 1. Projektkonfiguration (`GEMINI.md`)
+Erstellen Sie eine `GEMINI.md`-Datei im Stammverzeichnis Ihres Projekts, um dem KI-Agenten spezifischen Kontext und Entwicklungsregeln bereitzustellen:
+
+```markdown
+# Projektkontext
+
+- Dieses Projekt verwendet FastAPI und Pydantic v2.
+- Verwenden Sie immer `model_dump()` anstelle des veralteten `dict()`.
+- STRIKTE REGEL: Keine fest codierten Passwörter im Code. Importieren Sie alle Geheimnisse aus `.env`.
+```
+
+### 2. Globale Einstellungen (`~/.gemini/antigravity-cli/settings.json`)
+Die globale Einstellungsdatei steuert Berechtigungen zur Tool-Ausführung, Statuszeilen-/Titel-Skripte und MCP-Server:
+
+- **Linux/Unix**: `~/.gemini/antigravity-cli/settings.json`
+- **macOS**: `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows**: `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> Für eine erweiterte, reaktionsschnelle Statuszeile mit Echtzeit-Git-Status, Token-Zählern, Modellquoten und Strom-/Batteriestatus verwenden Sie das Plugin **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)**.
+
+
+### 3. Spezialisierte Agenten
+Sie können benutzerdefinierte Rollen und Anweisungen für KI-Agenten im JSON-Format beschreiben. Jeder Agent muss sein eigenes Verzeichnis haben, das eine `agent.json`-Datei enthält:
+
+- **Globale Agenten (Linux/Unix)**: `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **Globale Agenten (macOS)**: `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **Globale Agenten (Windows)**: `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **Lokale Agenten (Projektarbeitsbereich)**: `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "Analysiert Code vor dem Commit auf Schwachstellen",
+  "instructions": "Änderungen überprüfen auf:\n- OWASP Top 10 Schwachstellen\n- Durchsickern von API-Schlüsseln oder Geheimnissen\n- Richtigkeit der Firewall-/nftables-Konfiguration"
+}
+```
+
+---
+
+## 🔐 Authentifizierungsmethoden
+
+| Methode | Befehl / Variable | Einschränkungen & Funktionen |
+| :--- | :--- | :--- |
+| **Google Auth (Browser)** | Automatisch bei der ersten Ausführung von `agy` | Standard-Login. Kostenloses Limit: 60 Anfr./Min., 1000 Anfr./Tag |
+| **API-Schlüssel (Offline)** | `export GEMINI_API_KEY="X"` | Empfohlen für Server und Automatisierung |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | Enterprise-Level mit Google Cloud Cloud-Infrastruktur |
+| **Abmelden** | `/logout` | Löschen lokaler Sitzungstoken |
+
+---
+
+## 🔧 Befehlsreferenz
+
+### Befehlszeile
+```bash
+agy                              # Eine interaktive Sitzung starten
+agy -p "Prompt"                  # Einmalige Ausführung ohne Chat-Eingabe
+agy -c                           # Letzte unvollständige Konversation fortsetzen
+agy --conversation <ID>          # Sitzung mit einer bestimmten ID laden
+agy --sandbox                    # In einem isolierten Docker-Container ausführen
+agy update                       # Binärdatei auf die neueste Version aktualisieren
+agy plugin list                  # Installierte Plugins auflisten
+```
+
+### Slash-Befehle in der Chat-Schnittstelle
+*   `/help` — Hilfe zu verfügbaren Tools.
+*   `/settings` — Interaktive Konfiguration der Einstellungen.
+*   `/usage` — Statistik der verbrauchten Token und des Kontingents.
+*   `/diff` — Aktuelle ungespeicherte Änderungen im Projekt anzeigen.
+*   `/statusline` — Anzeige der Terminal-Statuszeile konfigurieren.
+
+---
+
+## 🔄 Migration von Gemini CLI
+
+> [!WARNING]
+> Das ursprüngliche Gemini CLI (`gemini`) stellt die Unterstützung für Nicht-Unternehmenskonten am **18. Juni 2026** ein. Die Migration zu Antigravity CLI ist erforderlich.
+
+### Schritte für einen schnellen Übergang
+1. Installieren Sie den neuen Client: `curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. Migrieren Sie lokale benutzerdefinierte Agentenkonfigurationsdateien (konvertieren Sie z. B. benutzerdefinierte Agenten von YAML in `~/.gemini/agents/` in JSON-Dateien unter `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`).
+3. Aktualisieren Sie CI/CD-Konfigurationen in GitHub Actions und ersetzen Sie `gemini`-Aufrufe durch `agy`.
+4. Deinstallieren Sie die alte Bibliothek: `npm uninstall -g @google/gemini-cli`
+
+### Vergleichstabelle
+
+| Funktion | Gemini CLI (Veraltet) | Antigravity CLI (Modern) |
+| :--- | :--- | :--- |
+| **Entwicklungsplattform** | Node.js / TypeScript | Go (Nativ kompilierte Binärdatei) |
+| **Befehlsname** | `gemini` | `agy` |
+| **Startgeschwindigkeit** | ~1.2s (Node.js-Start) | **~0.05s (sofortiger nativer Start)** |
+| **Konfigurationsdatei** | `GEMINI.md` | `GEMINI.md` |
+| **Automatische Aktualisierung** | Über `npm update` | Integrierter Selbstaktualisierungsmechanismus |
+| **Support-Status** | ⛔ EOL (18. Juni 2026) | ✅ Aktive Entwicklung (Upstream) |
+
+---
+
+## 📁 Repository-Struktur
+
+```
+antigravity-cli/
+├── install.sh           # Installer für Linux/macOS (offline/online)
+├── install.ps1          # Installer für Windows PowerShell (offline/online)
+├── install.cmd          # Installer für Windows CMD
+├── Makefile             # Automatisierungsziele (make install/reinstall/uninstall)
+├── GEMINI.md            # Projektkontext-Dateivorlage
+├── packages/            # Lokaler Offline-Vertrieb
+│   ├── manifests/       # Versionsmanifeste für alle Plattformen
+│   └── binaries/        # (Manuell erstellt für den Offline-Modus)
+└── CHANGELOG.md         # Changelog und Release-Protokoll
+```
+
+---
+
+## 🤝 Mitwirken & Community
+
+Dieses Repository ist ein unabhängiger Community-Fork des ursprünglichen Projekts [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli).
+
+**Unsere Verbesserungen:**
+*   🌍 Mehrsprachige Lokalisierungsunterstützung für Dokumente und Anleitungen.
+*   📦 Autonomie: Offline-Installationsmöglichkeit ohne Google-API-Downloads.
+*   🛠️ Komfort: `Makefile` für einen vereinfachten Lebenszyklus des Tools hinzugefügt.
+*   🛡️ Sicherheit: Regelmäßige Fehlerbehebungen und Verbesserungen an der Sandbox-Umgebung.
+
+---
+
+## 📜 Rechtlicher Hinweis & Markenrecht
+
+*   **Offizielle Links**: [Offizielles Dokumentations-Repo](https://github.com/google-antigravity/antigravity-cli) · [Offizielle CLI-Codebasis](https://github.com/google-gemini/gemini-cli) · [Offizielle Website](https://antigravity.google)
+*   **Nutzungsbedingungen**: [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **Rechtlicher Status des Forks:**
+> Dieses Repository ist eine unabhängige, nicht-kommerzielle Kopie (Community Fork) des Original-Clients. Es **ist kein** offizielles Produkt von Google LLC. Google LLC is nicht verantwortlich für die Leistung, Änderungen oder Sicherheit dieses Forks.
+> 
+> **Lizenzierung & Urheberrechte:**
+> Die Original-Software wird unter der [Apache-Lizenz 2.0](https://www.apache.org/licenses/LICENSE-2.0) verbreitet. Der gesamte Originalcode ist das geistige Eigentum von **Copyright © 2025 Google LLC**.
+> 
+> **Markennutzung:**
+> Der Name "Antigravity CLI" und die zugehörigen Logos werden im Rahmen der üblichen Nutzung ausschließlich zur Beschreibung der Herkunft, Kompatibilität und des funktionalen Zwecks der Software verwendet. Dieses Projekt erhebt keinen Anspruch auf Eigentumsrechte an Marken von Google LLC.
+> 
+> **Gewährleistungsausschluss:**
+> Die Software wird "WIE BESEHEN" bereitgestellt, OHNE GEWÄHRLEISTUNGEN JEGLICHER ART, weder ausdrücklich noch stillschweigend. Sie übernehmen die gesamte Verantwortung und alle Risiken im Zusammenhang mit ihrer Verwendung.
+
+> [!CAUTION]
+> KI-Codierungsagenten arbeiten autonom. Überprüfen Sie die vorgeschlagenen Diff-Blöcke und Befehle immer sorgfältig, bevor Sie die Ausführung bestätigen, insbesondere wenn Sie mit Systemdateien oder der Firewall-Konfiguration arbeiten.

--- a/README-ES.md
+++ b/README-ES.md
@@ -1,0 +1,245 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README-ZH.md">中文</a> | <b>Español</b> | <a href="README-FR.md">Français</a> | <a href="README-PT.md">Português</a> | <a href="README-UA.md">Українська</a> | <a href="README-DE.md">Deutsch</a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
+
+<h1 align="center">🚀 Antigravity CLI</h1>
+
+<p align="center">
+  <strong>Bifurcación de la comunidad y versión fuera de línea de google-antigravity/antigravity-cli con configuración automática de statusline y título de ventana</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.0-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
+
+<p align="center">
+  🤖 <b>Agente de codificación de IA directamente en su terminal</b>. Comprende el contexto de su código base, crea y edita archivos, ejecuta comandos seguros en un entorno aislado y resuelve tareas arquitectónicas complejas en una sola instrucción.
+</p>
+
+---
+
+## ⚡ Inicio rápido
+
+### Instalación instantánea (Primero fuera de línea y sin dependencias)
+Esta bifurcación descarga archivos binarios precompilados directamente desde los **activos de lanzamiento de GitHub (GitHub Release Assets)** (en lugar de los servidores de la API de Google). También se admite la instalación completamente fuera de línea (offline) si los archivos requeridos se cargaron previamente en la carpeta `packages/binaries/`.
+
+#### 🐧 Linux y 🍎 macOS
+```bash
+# Instalación a través de la red desde el repositorio de la bifurcación:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# O instalación fuera de línea desde un repositorio local:
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# (Opcional: descargue los archivos de la plataforma en packages/binaries/)
+make install
+```
+
+#### 🪟 Windows PowerShell
+```powershell
+# Instalación a través de la red:
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# O instalación fuera de línea desde un repositorio clonado:
+.\install.ps1
+```
+
+#### 🪟 Windows CMD
+```cmd
+# Instalación a través de la red:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# O instalación fuera de línea desde un repositorio clonado:
+install.cmd
+```
+
+---
+
+## 📋 Características principales
+
+> [!NOTE]
+> A diferencia de la versión original, esta bifurcación está adaptada para un funcionamiento estable en sesiones sin interfaz gráfica (headless)/SSH y laboratorios domésticos locales.
+
+*   📂 **Edición de archivos múltiples** — Edita varios archivos simultáneamente en su espacio de trabajo con confirmación previa de los cambios.
+*   🔒 **Comandos de shell seguros** — Ejecuta cualquier comando de terminal en el contenedor Docker incorporado (entorno aislado/sandbox) o en el sistema host.
+*   🧠 **Razonamiento de múltiples pasos (PAV)** — Construye de forma independiente un plan de ejecución de tareas, prueba el código y depura sus propios errores.
+*   💾 **Historial de conversación persistente** — Guarda el contexto completo de la conversación y el estado del espacio de trabajo entre sesiones.
+*   🔌 **Sistema de complementos** — Amplíe las capacidades del agente con *habilidades (Skills)* personalizadas y servidores MCP (Model Context Protocol).
+
+---
+
+## ⚙️ Configuración
+
+### 1. Configuración del proyecto (`GEMINI.md`)
+Cree un archivo `GEMINI.md` en la raíz de su proyecto para proporcionar un contexto específico y reglas de desarrollo al agente de IA:
+
+```markdown
+# Contexto del proyecto
+
+- Este proyecto utiliza FastAPI y Pydantic v2.
+- Utilice siempre `model_dump()` en lugar del obsoleto `dict()`.
+- REGLA ESTRICTA: No use contraseñas hardcoded en el código. Importe todos los secretos desde `.env`.
+```
+
+### 2. Configuración global (`~/.gemini/antigravity-cli/settings.json`)
+El archivo de configuración global controla los permisos de ejecución de herramientas, los scripts de statusline/título y los servidores MCP:
+
+- **Linux/Unix**: `~/.gemini/antigravity-cli/settings.json`
+- **macOS**: `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows**: `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> Para obtener una línea de estado avanzada y adaptable con seguimiento de estado de Git en tiempo real, contadores de tokens, cuotas de modelos y estado de energía/batería, use el complemento **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)**.
+
+
+### 3. Agentes especializados
+Puede describir roles e instrucciones personalizados para agentes de IA en formato JSON. Cada agente debe tener su propio directorio que contenga un archivo `agent.json`:
+
+- **Agentes Globales (Linux/Unix)**: `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **Agentes Globales (macOS)**: `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **Agentes Globales (Windows)**: `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **Agentes Locales (Espacio de Trabajo)**: `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "Analiza el código en busca de vulnerabilidades antes de confirmar",
+  "instructions": "Buscar en los cambios:\n- Vulnerabilidades OWASP Top 10\n- Filtración de claves de API o secretos\n- Corrección de la configuración del firewall/nftables"
+}
+```
+
+---
+
+## 🔐 Métodos de autenticación
+
+| Método | Comando / Variable | Limitaciones y características |
+| :--- | :--- | :--- |
+| **Autenticación de Google (Navegador)** | Automáticamente en el primer `agy` | Inicio de sesión estándar. Límite gratuito: 60 sol./min, 1000 sol./día |
+| **Clave de API (Fuera de línea)** | `export GEMINI_API_KEY="X"` | Recomendado para servidores y automatización |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | Nivel empresarial con la infraestructura en la nube de Google Cloud |
+| **Cerrar sesión** | `/logout` | Borrado de tokens de sesión local |
+
+---
+
+## 🔧 Referencia de comandos
+
+### Línea de comandos
+```bash
+agy                              # Iniciar una sesión interactiva
+agy -p "Mensaje de petición"     # Ejecución única sin ingresar al chat
+agy -c                           # Continuar la última conversación incompleta
+agy --conversation <ID>          # Cargar una sesión por un ID específico
+agy --sandbox                    # Ejecutar en un contenedor Docker aislado
+agy update                       # Actualizar el binario a la última versión
+agy plugin list                  # Listar los complementos instalados
+```
+
+### Comandos de barra diagonal (Slash Commands) en la interfaz de chat
+*   `/help` — Ayuda sobre las herramientas disponibles.
+*   `/settings` — Configuración interactiva de los ajustes.
+*   `/usage` — Estadísticas de tokens utilizados y cuota.
+*   `/diff` — Ver los cambios actuales no guardados en el proyecto.
+*   `/statusline` — Configurar la visualización de la línea de estado del terminal.
+
+---
+
+## 🔄 Migración desde Gemini CLI
+
+> [!WARNING]
+> La interfaz de línea de comandos original Gemini CLI (`gemini`) dejará de admitir cuentas que no sean empresariales el **18 de junio de 2026**. Se requiere la migración a Antigravity CLI.
+
+### Pasos para una transición rápida
+1. Instale el nuevo cliente: `curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. Migre los archivos de configuración de agentes personalizados locales (por ejemplo, convierta agentes personalizados de YAML dentro de `~/.gemini/agents/` a archivos JSON en `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`).
+3. Actualice las configuraciones de CI/CD en GitHub Actions, reemplazando las llamadas a `gemini` por `agy`.
+4. Desinstale la biblioteca antigua: `npm uninstall -g @google/gemini-cli`
+
+### Tabla de comparación
+
+| Característica | Gemini CLI (Obsoleto) | Antigravity CLI (Moderno) |
+| :--- | :--- | :--- |
+| **Plataforma de desarrollo** | Node.js / TypeScript | Go (Binario compilado nativo) |
+| **Nombre del comando** | `gemini` | `agy` |
+| **Velocidad de inicio** | ~1.2s (inicio de Node.js) | **~0.05s (inicio nativo instantáneo)** |
+| **Archivo de configuración** | `GEMINI.md` | `GEMINI.md` |
+| **Actualización automática** | A través de `npm update` | Mecanismo de auto-actualización incorporado |
+| **Estado del soporte** | ⛔ Fin de la vida útil (18 de junio de 2026) | ✅ Desarrollo activo (Upstream) |
+
+---
+
+## 📁 Estructura del repositorio
+
+```
+antigravity-cli/
+├── install.sh           # Instalador para Linux/macOS (fuera de línea/en línea)
+├── install.ps1          # Instalador para Windows PowerShell (fuera de línea/en línea)
+├── install.cmd          # Instalador para Windows CMD
+├── Makefile             # Destinos de automatización (make install/reinstall/uninstall)
+├── GEMINI.md            # Plantilla de archivo de contexto del proyecto
+├── packages/            # Distribución local fuera de línea
+│   ├── manifests/       # Manifiestos de versión para todas las plataformas
+│   └── binaries/        # (Creado manualmente para el modo fuera de línea)
+└── CHANGELOG.md         # Registro de cambios y registro de lanzamientos
+```
+
+---
+
+## 🤝 Contribuir y Comunidad
+
+Este repositorio es una bifurcación comunitaria independiente del proyecto original [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli).
+
+**Nuestras mejoras:**
+*   🌍 Soporte de localización en múltiples idiomas para documentos y guías.
+*   📦 Autonomía: capacidad de instalación fuera de línea sin descargas de la API de Google.
+*   🛠️ Conveniencia: se agregó `Makefile` para un ciclo de vida simplificado de la herramienta.
+*   🛡️ Seguridad: corrección periódica de errores y mejoras en el entorno aislado (sandbox).
+
+---
+
+## 📜 Aviso legal y de marca registrada
+
+*   **Enlaces oficiales**: [Repositorio de documentación oficial](https://github.com/google-antigravity/antigravity-cli) · [Código base oficial de la CLI](https://github.com/google-gemini/gemini-cli) · [Sitio web oficial](https://antigravity.google)
+*   **Condiciones de uso**: [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **Estado legal de la bifurcación:**
+> Este repositorio es una copia independiente no comercial (Bifurcación de la comunidad) del cliente original. **No es** un producto oficial de Google LLC. Google LLC no se hace responsable del rendimiento, las modificaciones o la seguridad de esta bifurcación.
+> 
+> **Licencias y derechos de autor:**
+> El software original se distribuye bajo la [Licencia Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Todo el código original es propiedad intelectual de **Copyright © 2025 Google LLC**.
+> 
+> **Uso de marcas registradas:**
+> El nombre "Antigravity CLI" y los logotipos asociados se utilizan dentro de los límites del uso consuetudinario únicamente para describir el origen, la compatibilidad y el propósito funcional del software. Este proyecto no reclama la propiedad de ninguna marca registrada de Google LLC.
+> 
+> **Renuncia de garantía:**
+> El software se proporciona "TAL CUAL", SIN GARANTÍAS DE NINGÚN TIPO, ya sean expresas o implícitas. Usted asume toda la responsabilidad y los riesgos asociados con su uso.
+
+> [!CAUTION]
+> Los agentes de codificación de IA funcionan de forma autónoma. Revise siempre con cuidado los bloques de diferencias (diff) y los comandos propuestos antes de confirmar la ejecución, especialmente cuando trabaje con archivos del sistema o la configuración del firewall.

--- a/README-FR.md
+++ b/README-FR.md
@@ -1,0 +1,245 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README-ZH.md">中文</a> | <a href="README-ES.md">Español</a> | <b>Français</b> | <a href="README-PT.md">Português</a> | <a href="README-UA.md">Українська</a> | <a href="README-DE.md">Deutsch</a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
+
+<h1 align="center">🚀 Antigravity CLI</h1>
+
+<p align="center">
+  <strong>Fork communautaire et version hors ligne renforcée de google-antigravity/antigravity-cli avec configuration automatique de la ligne d'état et du titre de la fenêtre</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.0-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
+
+<p align="center">
+  🤖 <b>Agent de codage IA directement dans votre terminal</b>. Comprend le contexte de votre base de code, crée et modifie des fichiers, exécute des commandes sécurisées dans un bac à sable et résout des tâches architecturales complexes en un seul prompt.
+</p>
+
+---
+
+## ⚡ Démarrage rapide
+
+### Installation instantanée (Hors ligne d'abord & Sans dépendance)
+Ce fork télécharge des fichiers binaires précompilés directement depuis les **GitHub Release Assets** (au lieu des serveurs de l'API Google). Une installation complètement hors ligne est également prise en charge si les archives requises ont été préalablement chargées dans le dossier `packages/binaries/`.
+
+#### 🐧 Linux et 🍎 macOS
+```bash
+# Installation réseau à partir du dépôt du fork :
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# OU installation hors ligne à partir d'un dépôt local :
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# (Optionnel : téléchargez les archives de la plateforme dans packages/binaries/)
+make install
+```
+
+#### 🪟 Windows PowerShell
+```powershell
+# Installation réseau :
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# OU installation hors ligne à partir d'un dépôt cloné :
+.\install.ps1
+```
+
+#### 🪟 Windows CMD
+```cmd
+# Installation réseau :
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# OU installation hors ligne à partir d'un dépôt cloné :
+install.cmd
+```
+
+---
+
+## 📋 Principales fonctionnalités
+
+> [!NOTE]
+> Contrairement à la version originale, ce fork est adapté pour un fonctionnement stable dans les sessions sans écran (headless)/SSH et les laboratoires locaux.
+
+*   📂 **Édition multi-fichiers** — Modifie plusieurs fichiers simultanément dans votre espace de travail avec confirmation préalable des modifications.
+*   🔒 **Commandes shell sécurisées** — Exécute toutes les commandes du terminal dans le conteneur Docker intégré (bac à sable/sandbox) ou sur le système hôte.
+*   🧠 **Raisonnement en plusieurs étapes (PAV)** — Construit de manière indépendante un plan d'exécution des tâches, teste le code et débogue ses propres erreurs.
+*   💾 **Historique persistant des conversations** — Enregistre le contexte complet de la conversation et l'état de l'espace de travail entre les sessions.
+*   🔌 **Système de plug-ins** — Étendez les capacités de l'agent avec des *compétences (Skills)* personnalisées et des serveurs MCP (Model Context Protocol).
+
+---
+
+## ⚙️ Configuration
+
+### 1. Configuration du projet (`GEMINI.md`)
+Créez un fichier `GEMINI.md` à la racine de votre projet pour fournir un contexte spécifique et des règles de développement à l'agent IA :
+
+```markdown
+# Contexte du projet
+
+- Ce projet utilise FastAPI et Pydantic v2.
+- Utilisez toujours `model_dump()` à la place de la méthode obsolète `dict()`.
+- RÈGLE STRICTE : Pas de mots de passe codés en dur dans le code. Importez tous les secrets depuis le fichier `.env`.
+```
+
+### 2. Paramètres globaux (`~/.gemini/antigravity-cli/settings.json`)
+Le fichier de configuration globale contrôle les autorisations d'exécution des outils, les scripts de statusline/titre et les serveurs MCP :
+
+- **Linux/Unix** : `~/.gemini/antigravity-cli/settings.json`
+- **macOS** : `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows** : `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> Pour une ligne de statut avancée et réactive avec suivi du statut Git en temps réel, compteurs de jetons, quotas de modèles et état d'alimentation/batterie, utilisez le plugin **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)**.
+
+
+### 3. Agents spécialisés
+Vous pouvez décrire des rôles et des instructions personnalisés pour les agents IA au format JSON. Chaque agent doit avoir son propre répertoire contenant un fichier `agent.json` :
+
+- **Agents Globaux (Linux/Unix)** : `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **Agents Globaux (macOS)** : `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **Agents Globaux (Windows)** : `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **Agents Locaux (Espace de Travail)** : `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "Analyse le code à la recherche de vulnérabilités avant le commit",
+  "instructions": "Vérifier les modifications pour :\n- Les 10 vulnérabilités majeures de l'OWASP\n- Les fuites de clés API ou de secrets\n- L'exactitude de la configuration du pare-feu/nftables"
+}
+```
+
+---
+
+## 🔐 Méthodes d'authentification
+
+| Méthode | Commande / Variable | Limites et fonctionnalités |
+| :--- | :--- | :--- |
+| **Authentification Google (Navigateur)** | Automatiquement lors du premier `agy` | Connexion standard. Limite gratuite : 60 requêtes/minute, 1000 requêtes/jour |
+| **Clé API (Hors ligne)** | `export GEMINI_API_KEY="X"` | Recommandé pour les serveurs et l'automatisation |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | Niveau entreprise avec l'infrastructure cloud Google Cloud |
+| **Déconnexion** | `/logout` | Effacement des jetons de session locale |
+
+---
+
+## 🔧 Référence des commandes
+
+### Ligne de commande
+```bash
+agy                              # Démarrer une session interactive
+agy -p "Prompt"                  # Exécution unique sans entrer dans le chat
+agy -c                           # Continuer la dernière conversation incomplète
+agy --conversation <ID>          # Charger une session par un ID spécifique
+agy --sandbox                    # Exécuter dans un conteneur Docker isolé
+agy update                       # Mettre à jour le binaire vers la dernière version
+agy plugin list                  # Lister les plug-ins installés
+```
+
+### Commandes slash dans l'interface de chat
+*   `/help` — Aide sur les outils disponibles.
+*   `/settings` — Configuration interactive des paramètres.
+*   `/usage` — Statistiques des jetons consommés et quota.
+*   `/diff` — Afficher les modifications actuelles non sauvegardées dans le projet.
+*   `/statusline` — Configurer l'affichage de la ligne d'état du terminal.
+
+---
+
+## 🔄 Migration depuis Gemini CLI
+
+> [!WARNING]
+> L'interface de ligne de commande originale Gemini CLI (`gemini`) abandonnera le support pour les comptes non professionnels le **18 juin 2026**. La migration vers Antigravity CLI est requise.
+
+### Étapes pour une transition rapide
+1. Installez le nouveau client : `curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. Migrez les fichiers de configuration des agents personnalisés locaux (par exemple, convertissez les agents personnalisés de YAML dans `~/.gemini/agents/` en fichiers JSON sous `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`).
+3. Mettez à jour les configurations CI/CD dans GitHub Actions, en remplaçant les appels `gemini` par `agy`.
+4. Désinstallez l'ancienne bibliothèque : `npm uninstall -g @google/gemini-cli`
+
+### Tableau comparatif
+
+| Fonctionnalité | Gemini CLI (Obsolète) | Antigravity CLI (Moderne) |
+| :--- | :--- | :--- |
+| **Plateforme de développement** | Node.js / TypeScript | Go (Binaire natif compilé) |
+| **Nom de la commande** | `gemini` | `agy` |
+| **Vitesse de démarrage** | ~1.2s (démarrage Node.js) | **~0.05s (démarrage natif instantané)** |
+| **Fichier de configuration** | `GEMINI.md` | `GEMINI.md` |
+| **Mise à jour automatique** | Via `npm update` | Mécanisme d'auto-mise à jour intégré |
+| **Statut du support** | ⛔ EOL (18 juin 2026) | ✅ Développement actif (Upstream) |
+
+---
+
+## 📁 Structure du dépôt
+
+```
+antigravity-cli/
+├── install.sh           # Programme d'installation pour Linux/macOS (hors ligne/en ligne)
+├── install.ps1          # Programme d'installation pour Windows PowerShell (hors ligne/en ligne)
+├── install.cmd          # Programme d'installation pour Windows CMD
+├── Makefile             # Cibles d'automatisation (make install/reinstall/uninstall)
+├── GEMINI.md            # Modèle de fichier de contexte de projet
+├── packages/            # Distribution hors ligne locale
+│   ├── manifests/       # Manifestes de version pour toutes les plateformes
+│   └── binaries/        # (Créé manuellement pour le mode hors ligne)
+└── CHANGELOG.md         # Journal des modifications et des versions
+```
+
+---
+
+## 🤝 Contribution & Communauté
+
+Ce dépôt est un fork communautaire indépendant du projet original [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli).
+
+**Nos améliorations :**
+*   🌍 Prise en charge de la localisation multilingue pour la documentation et les guides.
+*   📦 Autonomie : capacité d'installation hors ligne sans téléchargements depuis les API Google.
+*   🛠️ Praticité : ajout d'un `Makefile` pour un cycle de vie simplifié de l'outil.
+*   🛡️ Sécurité : corrections régulières de bogues et améliorations de l'environnement de bac à sable.
+
+---
+
+## 📜 Avis légal & Propriété intellectuelle
+
+*   **Liens officiels** : [Dépôt de documentation officiel](https://github.com/google-antigravity/antigravity-cli) · [Base de code officielle de la CLI](https://github.com/google-gemini/gemini-cli) · [Site officiel](https://antigravity.google)
+*   **Conditions d'utilisation** : [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **Statut juridique du fork :**
+> Ce dépôt est une copie indépendante non commerciale (Community Fork) du client d'origine. Ce **n'est pas** un produit officiel de Google LLC. Google LLC n'est pas responsable des performances, des modifications ou de la sécurité de ce fork.
+> 
+> **Licences et droits d'auteur :**
+> Le logiciel d'origine est distribué sous la [Licence Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Tout le code d'origine est la propriété intellectuelle de **Copyright © 2025 Google LLC**.
+> 
+> **Utilisation de la marque :**
+> Le nom "Antigravity CLI" et les logos associés sont utilisés dans les limites de l'usage coutumier uniquement pour décrire l'origine, la compatibilité et le but fonctionnel du logiciel. Ce projet ne revendique aucun droit de propriété sur les marques de Google LLC.
+> 
+> **Exclusion de garantie :**
+> Le logiciel est fourni "EN L'ÉTAT", SANS GARANTIE D'AUCUNE SORTE, expresse ou implicite. Vous assumez toute responsabilité et tous les risques associés à son utilisation.
+
+> [!CAUTION]
+> Les agents de codage IA fonctionnent de manière autonome. Examinez toujours attentivement les blocs de diff proposés et les commandes avant de confirmer l'exécution, en particulier lorsque vous travaillez avec des fichiers système ou la configuration du pare-feu.

--- a/README-PT.md
+++ b/README-PT.md
@@ -1,0 +1,245 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README-ZH.md">中文</a> | <a href="README-ES.md">Español</a> | <a href="README-FR.md">Français</a> | <b>Português</b> | <a href="README-UA.md">Українська</a> | <a href="README-DE.md">Deutsch</a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
+
+<h1 align="center">🚀 Antigravity CLI</h1>
+
+<p align="center">
+  <strong>Fork da comunidade e versão offline de google-antigravity/antigravity-cli com configuração automática de statusline e título de janela</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.0-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
+
+<p align="center">
+  🤖 <b>Agente de codificação de IA diretamente no seu terminal</b>. Compreende o contexto da sua base de código, cria e edita arquivos, executa comandos seguros em uma sandbox e resolve tarefas arquitetônicas complexas em um único prompt.
+</p>
+
+---
+
+## ⚡ Início Rápido
+
+### Instalação Instantânea (Foco em Offline e Sem Dependências)
+Este fork faz o download de binários pré-compilados diretamente dos **GitHub Release Assets** (em vez dos servidores de API da Google). A instalação totalmente offline também é suportada se os arquivos necessários tiverem sido previamente carregados na pasta `packages/binaries/`.
+
+#### 🐧 Linux e 🍎 macOS
+```bash
+# Instalação via rede a partir do repositório do fork:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# OU instalação offline a partir de um repositório local:
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# (Opcional: baixe os arquivos da plataforma em packages/binaries/)
+make install
+```
+
+#### 🪟 Windows PowerShell
+```powershell
+# Instalação via rede:
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# OU instalação offline a partir de um repositório clonado:
+.\install.ps1
+```
+
+#### 🪟 Windows CMD
+```cmd
+# Instalação via rede:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# OU instalação offline a partir de um repositório clonado:
+install.cmd
+```
+
+---
+
+## 📋 Recursos Principais
+
+> [!NOTE]
+> Ao contrário da versão original, este fork é adaptado para uma operação estável em sessões headless/SSH e laboratórios domésticos locais.
+
+*   📂 **Edição de Múltiplos Arquivos** — Edita vários arquivos simultaneamente no seu espaço de trabalho com confirmação prévia das alterações.
+*   🔒 **Comandos de Shell Seguros** — Executa qualquer comando de terminal no container Docker integrado (sandbox) ou no sistema host.
+*   🧠 **Raciocínio em Várias Etapas (PAV)** — Constrói de forma independente um plano de execução de tarefas, testa o código e depura os seus próprios erros.
+*   💾 **Histórico de Conversa Persistente** — Salva o contexto completo da conversa e o estado do espaço de trabalho entre as sessões.
+*   🔌 **Sistema de Plugins** — Estenda as capacidades do agente com *habilidades (Skills)* personalizadas e servidores MCP (Model Context Protocol).
+
+---
+
+## ⚙️ Configuração
+
+### 1. Configuração do Projeto (`GEMINI.md`)
+Crie um arquivo `GEMINI.md` na raiz do seu projeto para fornecer contexto específico e regras de desenvolvimento ao agente de IA:
+
+```markdown
+# Contexto do Projeto
+
+- Este projeto usa FastAPI e Pydantic v2.
+- Sempre use `model_dump()` em vez do obsoleto `dict()`.
+- REGRA ESTRITA: Sem senhas expostas no código (hardcoded). Importe todos os segredos do `.env`.
+```
+
+### 2. Configurações Globais (`~/.gemini/antigravity-cli/settings.json`)
+O arquivo de configuração global controla as permissões de execução de ferramentas, scripts de statusline/título e servidores MCP:
+
+- **Linux/Unix**: `~/.gemini/antigravity-cli/settings.json`
+- **macOS**: `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows**: `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> Para obter uma linha de status avançada e responsiva com rastreamento de status Git em tempo real, medidores de tokens, cotas de modelos e estado de energia/batería, use o plugin **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)**.
+
+
+### 3. Agentes Especializados
+Você pode descrever funções e instruções personalizadas para agentes de IA no formato JSON. Cada agente deve ter seu próprio diretório contendo um arquivo `agent.json`:
+
+- **Agentes Globais (Linux/Unix)**: `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **Agentes Globais (macOS)**: `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **Agentes Globais (Windows)**: `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **Agentes Locais (Espaço de Trabalho)**: `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "Analisa o código em busca de vulnerabilidades antes do commit",
+  "instructions": "Verificar alterações para:\n- Vulnerabilidades OWASP Top 10\n- Vazamento de chaves de API ou segredos\n- Correção da configuração do firewall/nftables"
+}
+```
+
+---
+
+## 🔐 Métodos de Autenticação
+
+| Método | Comando / Variável | Limitações e Recursos |
+| :--- | :--- | :--- |
+| **Google Auth (Navegador)** | Automaticamente no primeiro `agy` | Login padrão. Limite gratuito: 60 req/min, 1000 req/dia |
+| **Chave de API (Offline)** | `export GEMINI_API_KEY="X"` | Recomendado para servidores e automação |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | Nível corporativo com infraestrutura em nuvem do Google Cloud |
+| **Sair (Sign Out)** | `/logout` | Limpeza de tokens de sessão local |
+
+---
+
+## 🔧 Referência de Comandos
+
+### Linha de Comando
+```bash
+agy                              # Iniciar uma sessão interativa
+agy -p "Prompt"                  # Execução única sem entrar no chat
+agy -c                           # Continuar a última conversa incompleta
+agy --conversation <ID>          # Carregar uma sessão por um ID específico
+agy --sandbox                    # Executar em um container Docker isolado
+agy update                       # Atualizar o binário para a versão mais recente
+agy plugin list                  # Listar os plugins instalados
+```
+
+### Comandos de Barra (Slash Commands) na Interface de Chat
+*   `/help` — Ajuda sobre ferramentas disponíveis.
+*   `/settings` — Configuração interativa de definições.
+*   `/usage` — Estatísticas de tokens gastos e cota.
+*   `/diff` — Visualizar as alterações atuais não salvas no projeto.
+*   `/statusline` — Configurar a exibição da linha de status do terminal.
+
+---
+
+## 🔄 Migração do Gemini CLI
+
+> [!WARNING]
+> A interface de linha de comando original Gemini CLI (`gemini`) deixará de oferecer suporte para contas não corporativas em **18 de junho de 2026**. A migração para o Antigravity CLI é necessária.
+
+### Passos para Transição Rápida
+1. Instale o novo cliente: `curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. Migre os arquivos de configuração de agentes personalizados locais (por exemplo, converta agentes personalizados de YAML dentro de `~/.gemini/agents/` em arquivos JSON em `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`).
+3. Atualize as configurações de CI/CD no GitHub Actions, substituindo as chamadas de `gemini` por `agy`.
+4. Desinstale a biblioteca antiga: `npm uninstall -g @google/gemini-cli`
+
+### Tabela de Comparação
+
+| Recurso | Gemini CLI (Legado) | Antigravity CLI (Moderno) |
+| :--- | :--- | :--- |
+| **Plataforma de Desenvolvimento** | Node.js / TypeScript | Go (Binário Nativo Compilado) |
+| **Nome do Comando** | `gemini` | `agy` |
+| **Velocidade de Inicialização** | ~1.2s (inicialização do Node.js) | **~0.05s (inicialização nativa instantânea)** |
+| **Arquivo de Configuração** | `GEMINI.md` | `GEMINI.md` |
+| **Atualização Automática** | Via `npm update` | Mecanismo de auto-atualização integrado |
+| **Status do Suporte** | ⛔ Fim da vida útil (18 de junho de 2026) | ✅ Desenvolvimento Ativo (Upstream) |
+
+---
+
+## 📁 Estrutura do Repositório
+
+```
+antigravity-cli/
+├── install.sh           # Instalador para Linux/macOS (offline/online)
+├── install.ps1          # Instalador para Windows PowerShell (offline/online)
+├── install.cmd          # Instalador para Windows CMD
+├── Makefile             # Metas de automação (make install/reinstall/uninstall)
+├── GEMINI.md            # Modelo de arquivo de contexto de projeto
+├── packages/            # Distribuição offline local
+│   ├── manifests/       # Manifestes de versão para todas as plataformas
+│   └── binaries/        # (Criado manualmente para o modo offline)
+└── CHANGELOG.md         # Registro de alterações e lançamentos
+```
+
+---
+
+## 🤝 Contribuição & Comunidade
+
+Este repositório é um fork da comunidade independente do projeto original [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli).
+
+**Nossas Melhorias:**
+*   🌍 Suporte de localização em vários idiomas para documentos e guias.
+*   📦 Autonomia: capacidade de instalação offline sem downloads da API da Google.
+*   🛠️ Conveniência: adicionado `Makefile` para um ciclo de vida simplificado da ferramenta.
+*   🛡️ Segurança: correções regulares de bugs e melhorias no ambiente de sandbox.
+
+---
+
+## 📜 Aviso Legal & Marcas Registradas
+
+*   **Links Oficiais**: [Repositório Oficial de Documentação](https://github.com/google-antigravity/antigravity-cli) · [Base de Código Oficial do CLI](https://github.com/google-gemini/gemini-cli) · [Website Oficial](https://antigravity.google)
+*   **Termos de Uso**: [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **Status Legal do Fork:**
+> Este repositório é uma cópia independente não comercial (Fork da Comunidade) do cliente original. Ele **não é** um produto oficial da Google LLC. A Google LLC não se responsabiliza pelo desempenho, modificações ou segurança deste fork.
+> 
+> **Licenciamento & Direitos Autorais:**
+> O software original é distribuído sob a [Licença Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). Todo o código original é propriedade intelectual de **Copyright © 2025 Google LLC**.
+> 
+> **Uso de Marca Registrada:**
+> O nome "Antigravity CLI" e os logotipos associados são usados dentro dos limites do Uso Habitual exclusivamente para descrever a origem, compatibilidade e propósito funcional do software. Este projeto não reivindica a propriedade de nenhuma marca registrada da Google LLC.
+> 
+> **Isenção de Garantia:**
+> O software é fornecido "COMO ESTÁ", SEM GARANTIAS DE QUALQUER TIPO, expressas ou implícitas. Você assume toda a responsabilidade e riscos associados ao seu uso.
+
+> [!CAUTION]
+> Os agentes de codificação de IA operam de forma autônoma. Sempre revise cuidadosamente os blocos de diff propostos e os comandos antes de confirmar a execução, especialmente ao trabalhar com arquivos do sistema ou configuração do firewall.

--- a/README-UA.md
+++ b/README-UA.md
@@ -1,0 +1,245 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README-ZH.md">中文</a> | <a href="README-ES.md">Español</a> | <a href="README-FR.md">Français</a> | <a href="README-PT.md">Português</a> | <b>Українська</b> | <a href="README-DE.md">Deutsch</a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
+
+<h1 align="center">🚀 Antigravity CLI</h1>
+
+<p align="center">
+  <strong>Ком'юніті-форк та покращена офлайн-версія google-antigravity/antigravity-cli з автоналаштуванням статуслайну та заголовка вікна</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.5-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
+
+<p align="center">
+  🤖 <b>ШІ-кодинг агент прямо у вашому терміналі</b>. Розуміє контекст вашої кодової бази, створює та редагує файли, виконує безпечні команди в пісочниці та вирішує комплексні архітектурні завдання за один промпт.
+</p>
+
+---
+
+## ⚡ Швидкий старт
+
+### Миттєве встановлення (Offline-first & Zero-dependency)
+Цей форк завантажує попередньо скомпільовані бінарні файли прямо з **GitHub Release Assets** (замість серверів Google API). Також підтримується повністю автономне офлайн-встановлення, якщо потрібні архіви було попередньо завантажено в папку `packages/binaries/`.
+
+#### 🐧 Linux та 🍎 macOS
+```bash
+# Мережеве встановлення з репозиторію форку:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# АБО автономне офлайн-встановлення з локального репозиторію:
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# (Опціонально: завантажте архіви платформ у packages/binaries/)
+make install
+```
+
+#### 🪟 Windows PowerShell
+```powershell
+# Мережеве встановлення:
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# АБО офлайн-встановлення з клонованого репозиторію:
+.\install.ps1
+```
+
+#### 🪟 Windows CMD
+```cmd
+# Мережеве встановлення:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# АБО офлайн-встановлення з клонованого репозиторію:
+install.cmd
+```
+
+---
+
+## 📋 Основні можливості
+
+> [!NOTE]
+> На відміну від оригінальної версії, цей форк адаптований для стабільної роботи в headless/SSH-сесіях та локальних home-лабораторіях.
+
+*   📂 **Мультифайлове редагування** — Редагує декілька файлів одночасно у вашому робочому просторі з попереднім підтвердженням змін.
+*   🔒 **Безпечні Shell-команди** — Виконує будь-які термінальні команди у вбудованому Docker-контейнері (пісочниці) або на хост-системі.
+*   🧠 **Багатокрокові міркування (PAV)** — Самостійно будує план виконання завдання, тестує код і виправляє власні помилки.
+*   💾 **Постійна історія розмов** — Зберігає повний контекст розмови та стан робочого простору між сесіями.
+*   🔌 **Система плагінів** — Розширюйте можливості агента за допомогою кастомних *Skills* та MCP-серверів (Model Context Protocol).
+
+---
+
+## ⚙️ Конфігурація
+
+### 1. Конфігурація проєкту (`GEMINI.md`)
+Створіть файл `GEMINI.md` у корені вашого проєкту, щоб передати ШІ-агенту специфічний контекст та правила розробки:
+
+```markdown
+# Контекст проєкту
+
+- Цей проєкт використовує FastAPI та Pydantic v2.
+- Завжди використовуйте `model_dump()` замість застарілого `dict()`.
+- СУВОРЕ ПРАВИЛО: Жодних хардкод-паролів у коді. Всі секрети імпортувати з `.env`.
+```
+
+### 2. Глобальні налаштування (`~/.gemini/antigravity-cli/settings.json`)
+Глобальний файл налаштувань керує дозволами на виконання інструментів, скриптами статуслайну/заголовка та MCP-серверами:
+
+- **Linux/Unix**: `~/.gemini/antigravity-cli/settings.json`
+- **macOS**: `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows**: `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> Для отримання просунутого та адаптивного статус-бару з відстеженням Git-статусу в реальному часі, лічильником токенів, квотами моделей та станом живлення/батареї, скористайтеся плагіном **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)**.
+
+
+### 3. Спеціалізовані агенти
+Ви можете описувати кастомні ролі та інструкції для ШІ-агентів у форматі JSON. Кожен агент повинен мати власну директорію, яка містить файл `agent.json`:
+
+- **Глобальні агенти (Linux/Unix)**: `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **Глобальні агенти (macOS)**: `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **Глобальні агенти (Windows)**: `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **Локальні агенти (Робочий простір)**: `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "Аналізує код на вразливості перед комітом",
+  "instructions": "Перевіряти зміни на:\n- OWASP Top 10 вразливості\n- Витік API ключів чи секретів\n- Правильність налаштування firewall/nftables"
+}
+```
+
+---
+
+## 🔐 Способи авторизації
+
+| Метод | Команда / Змінна | Обмеження та особливості |
+| :--- | :--- | :--- |
+| **Google Auth (Browser)** | Автоматично при першому `agy` | Стандартний вхід. Безкоштовний ліміт: 60 з/хв, 1000 з/добу |
+| **API Key (Offline)** | `export GEMINI_API_KEY="X"` | Рекомендовано для серверів та автоматизації |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | Enterprise-рівень з хмарною інфраструктурою Google Cloud |
+| **Вихід з профілю** | `/logout` | Очищення локальних токенів сесії |
+
+---
+
+## 🔧 Довідка команд
+
+### Командний рядок
+```bash
+agy                              # Запустити інтерактивну сесію
+agy -p "Запит"                   # Одноразове виконання без входу в чат
+agy -c                           # Продовжити останню незавершену розмову
+agy --conversation <ID>          # Завантажити сесію за конкретним ідентифікатором
+agy --sandbox                    # Запустити в ізольованому Docker-контейнері
+agy update                       # Оновити бінарний файл до останньої версії
+agy plugin list                  # Список встановлених плагінів
+```
+
+### Slash-команди в інтерфейсі чату
+*   `/help` — Довідка з доступних інструментів.
+*   `/settings` — Інтерактивне налаштування параметрів.
+*   `/usage` — Статистика витрачених токенів та квоти.
+*   `/diff` — Перегляд поточних незбережених змін у проєкті.
+*   `/statusline` — Налаштування відображення статус-бару терміналу.
+
+---
+
+## 🔄 Злиття та міграція з Gemini CLI
+
+> [!WARNING]
+> Оригінальний Gemini CLI (`gemini`) припиняє підтримку для non-enterprise акаунтів **18 червня 2026**. Перехід на Antigravity CLI є обов'язковим.
+
+### Кроки для швидкого переходу
+1. Встановіть новий клієнт: `curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. Мігруйте локальні файли конфігурації кастомних агентів (наприклад, конвертуйте конфігурації YAML у папці `~/.gemini/agents/` в JSON-файли за шляхом `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`).
+3. Оновіть CI/CD конфігурації в GitHub Actions, замінивши виклики `gemini` на `agy`.
+4. Видаліть стару бібліотеку: `npm uninstall -g @google/gemini-cli`
+
+### Порівняльна таблиця
+
+| Характеристика | Gemini CLI (Застарілий) | Antigravity CLI (Сучасний) |
+| :--- | :--- | :--- |
+| **Платформа розробки** | Node.js / TypeScript | Go (Native Compiled Binary) |
+| **Назва команди** | `gemini` | `agy` |
+| **Швидкість старту** | ~1.2 сек (запуск Node.js) | **~0.05 сек (миттєвий нативний старт)** |
+| **Файл конфігурації** | `GEMINI.md` | `GEMINI.md` |
+| **Авто-оновлення** | Через `npm update` | Вбудований механізм self-update |
+| **Статус підтримки** | ⛔ EOL (18.06.2026) | ✅ Активна розробка (Upstream) |
+
+---
+
+## 📁 Структура репозиторію
+
+```
+antigravity-cli/
+├── install.sh           # Інсталятор для Linux/macOS (офлайн/онлайн)
+├── install.ps1          # Інсталятор для Windows PowerShell (офлайн/онлайн)
+├── install.cmd          # Інсталятор для Windows CMD
+├── Makefile             # Автоматизовані цілі (make install/reinstall/uninstall)
+├── GEMINI.md            # Шаблон файлу контексту проєкту
+├── packages/            # Локальний офлайн-дистрибутив
+│   ├── manifests/       # Маніфести версій для всіх платформ
+│   └── binaries/        # (Створюється вручну для офлайн-режиму)
+└── CHANGELOG.md         # Журнал версій та релізів
+```
+
+---
+
+## 🤝 Спільнота та розробка (Contributing)
+
+Цей репозиторій є незалежним ком'юніті-форком оригінального проєкту [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli).
+
+**Наші покращення:**
+*   🇺🇦 Повна українська локалізація документації та гайдів.
+*   📦 Автономність: можливість офлайн-встановлення без завантажень з Google API.
+*   🛠️ Зручність: додано `Makefile` для спрощеного життєвого циклу інструменту.
+*   🛡️ Безпека: регулярні баг-фікси та покращення роботи в пісочниці (сандбоксі).
+
+---
+
+## 📜 Юридичний статус та дисклеймер (Legal & Trademark Notice)
+
+*   **Офіційні посилання**: [Офіційний репозиторій документації](https://github.com/google-antigravity/antigravity-cli) · [Офіційна кодова база CLI](https://github.com/google-gemini/gemini-cli) · [Офіційний сайт](https://antigravity.google)
+*   **Правила використання**: [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **Правовий статус форку:**
+> Цей репозиторій є незалежною некомерційною копією (Community Fork) оригінального клієнта. Він **не є** офіційним продуктом компанії Google LLC. Google LLC не несе відповідальності за працездатність, модифікації або безпеку цього форку.
+> 
+> **Ліцензування та авторські права:**
+> Оригінальне програмне забезпечення розповсюджується під ліцензією [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). Весь оригінальний код є інтелектуальною власністю **Copyright © 2025 Google LLC**.
+> 
+> **Використання торгових марок:**
+> Назва "Antigravity CLI" та пов'язані логотипи використовуються в межах дозволеного використання (Customary Use) виключно для опису походження, сумісності та функціонального призначення програмного забезпечення. Цей проєкт не претендує на володіння будь-якими торговими марками Google LLC.
+> 
+> **Обмеження відповідальності (Disclaimer of Warranty):**
+> Програмне забезпечення надається на умовах «ЯК Є» (AS IS), БЕЗ БУДЬ-ЯКИХ ГАРАНТІЙ, явних чи неявних. Ви берете на себе всю відповідальність та ризики, пов'язані з його використанням.
+
+> [!CAUTION]
+> ШІ-агенти для кодування працюють автономно. Завжди уважно перевіряйте пропоновані diff-блоки та команди перед підтвердженням виконання, особливо при роботі з системними файлами чи конфігурацією фаєрволу.

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -1,0 +1,245 @@
+<p align="center">
+  <a href="README.md">English</a> | <b>中文</b> | <a href="README-ES.md">Español</a> | <a href="README-FR.md">Français</a> | <a href="README-PT.md">Português</a> | <a href="README-UA.md">Українська</a> | <a href="README-DE.md">Deutsch</a>
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
+
+<h1 align="center">🚀 Antigravity CLI</h1>
+
+<p align="center">
+  <strong>社区分叉与硬化离线版 google-antigravity/antigravity-cli，支持状态栏和窗口标题的自动设置</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.0-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
+
+<p align="center">
+  🤖 <b>直接在您的终端中运行 of AI 编码智能体</b>。理解您的代码库上下文，创建和编辑文件，在沙箱中执行安全命令，并在单个提示词中解决复杂的架构任务。
+</p>
+
+---
+
+## ⚡ 快速开始
+
+### 即时安装（离线优先与零依赖）
+此分叉版本直接从 **GitHub Release Assets**（而不是 Google API 服务器）下载预编译的二进制文件。如果预先将所需的归档文件加载到 `packages/binaries/` 文件夹中，则同样支持完全自治的离线安装。
+
+#### 🐧 Linux 和 🍎 macOS
+```bash
+# 从分叉存储库进行网络安装：
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# 或者从本地存储库进行离线安装：
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# （可选：将对应平台的归档文件下载到 packages/binaries/ 中）
+make install
+```
+
+#### 🪟 Windows PowerShell
+```powershell
+# 网络安装：
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# 或者从克隆的存储库进行离线安装：
+.\install.ps1
+```
+
+#### 🪟 Windows CMD
+```cmd
+# 网络安装：
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# 或者从克隆的存储库进行离线安装：
+install.cmd
+```
+
+---
+
+## 📋 核心功能
+
+> [!NOTE]
+> 与原始版本不同，此分叉版本经过特别优化，适用于无头（headless）环境、SSH 会话以及本地家庭实验室（Home Labs）中的稳定运行。
+
+*   📂 **多文件编辑** — 在您的工作区中同时编辑多个文件，并在应用更改前进行确认。
+*   🔒 **安全 Shell 命令** — 在内置的 Docker 容器（沙箱）或主机系统上执行任意终端命令。
+*   🧠 **多步推理 (PAV)** — 独立构建任务执行计划，测试代码并调试自身的错误。
+*   💾 **持久化会话历史记录** — 在会话之间保存完整的对话上下文和工作区状态。
+*   🔌 **插件系统** — 使用自定义 *技能 (Skills)* 和 MCP（Model Context Protocol，模型上下文协议）服务器扩展智能体的能力。
+
+---
+
+## ⚙️ 配置方式
+
+### 1. 项目配置 (`GEMINI.md`)
+在项目的根目录下创建一个 `GEMINI.md` 文件，为 AI 智能体提供特定的项目上下文和开发规则：
+
+```markdown
+# 项目上下文
+
+- 本项目使用 FastAPI 和 Pydantic v2。
+- 请始终使用 `model_dump()` 代替已废弃的 `dict()`。
+- 严格规则：严禁在代码中硬编码任何密码。所有机密信息必须从 `.env` 文件导入。
+```
+
+### 2. 全局设置 (`~/.gemini/antigravity-cli/settings.json`)
+全局配置文件控制工具执行权限、状态栏/窗口标题脚本以及 MCP 服务器：
+
+- **Linux/Unix**: `~/.gemini/antigravity-cli/settings.json`
+- **macOS**: `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows**: `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> 如需具有实时 Git 状态跟踪、Token 计数器、模型配额以及电源/电池状态的高级响应式状态栏，请使用 **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)** 插件。
+
+
+### 3. 专业智能体
+您可以使用 JSON 格式定义 AI 智能体的自定义角色和说明。每个智能体必须有自己的目录，其中包含一个 `agent.json` 文件：
+
+- **全局智能体 (Linux/Unix)**: `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **全局智能体 (macOS)**: `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **全局智能体 (Windows)**: `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **本地智能体 (项目工作区)**: `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "在提交前分析代码漏洞",
+  "instructions": "检查更改内容：\n- OWASP Top 10 漏洞\n- API 密钥或凭证泄露\n- 防火墙/nftables 配置正确性"
+}
+```
+
+---
+
+## 🔐 身份验证方式
+
+| 方法 | 命令 / 环境变量 | 限制与特点 |
+| :--- | :--- | :--- |
+| **Google 身份验证（浏览器）** | 首次运行 `agy` 时自动触发 | 标准登录。免费限制：60 次请求/分钟，1000 次请求/天 |
+| **API 密钥（离线）** | `export GEMINI_API_KEY="X"` | 推荐用于服务器环境和自动化工作流 |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | 企业级方案，使用 Google Cloud 云基础设施 |
+| **注销登录** | `/logout` | 清除本地会话令牌 |
+
+---
+
+## 🔧 常用命令参考
+
+### 命令行工具
+```bash
+agy                              # 启动交互式会话
+agy -p "提示词"                  # 单次执行，不进入聊天界面
+agy -c                           # 继续上一次未完成的对话
+agy --conversation <ID>          # 通过特定 ID 加载会话
+agy --sandbox                    # 在隔离的 Docker 容器中运行
+agy update                       # 更新二进制文件到最新版本
+agy plugin list                  # 列出已安装的插件
+```
+
+### 聊天界面中的斜杠命令 (Slash Commands)
+*   `/help` — 获取可用工具的帮助信息。
+*   `/settings` — 交互式配置设置项。
+*   `/usage` — 消耗的令牌（Token）数量和配额统计。
+*   `/diff` — 查看项目中当前未保存的更改。
+*   `/statusline` — 配置终端状态栏的显示。
+
+---
+
+## 🔄 从 Gemini CLI 迁移
+
+> [!WARNING]
+> 原始的 Gemini CLI (`gemini`) 将于 **2026 年 6 月 18 日**起停止对非企业账户的支持。请及时迁移到 Antigravity CLI。
+
+### 快速迁移步骤
+1. 安装新客户端：`curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. 迁移本地自定义智能体配置文件（例如，将 `~/.gemini/agents/` 下的 YAML 格式自定义智能体转换为 `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json` 下的 JSON 文件）。
+3. 更新 GitHub Actions 中的 CI/CD 配置，将所有的 `gemini` 调用替换为 `agy`。
+4. 卸载旧的依赖库：`npm uninstall -g @google/gemini-cli`
+
+### 对比表
+
+| 功能 / 属性 | Gemini CLI (旧版) | Antigravity CLI (新版) |
+| :--- | :--- | :--- |
+| **开发语言/平台** | Node.js / TypeScript | Go (原生编译的二进制文件) |
+| **执行命令** | `gemini` | `agy` |
+| **启动速度** | ~1.2秒 (Node.js 启动延迟) | **~0.05秒 (原生瞬间启动)** |
+| **项目配置文件** | `GEMINI.md` | `GEMINI.md` |
+| **自动更新** | 通过 `npm update` | 内置的自我更新机制 |
+| **维护状态** | ⛔ 已停止支持 (2026年6月18日) | ✅ 持续活跃开发 (上游支持) |
+
+---
+
+## 📁 存储库结构
+
+```
+antigravity-cli/
+├── install.sh           # Linux/macOS 安装程序 (离线/在线)
+├── install.ps1          # Windows PowerShell 安装程序 (离线/在线)
+├── install.cmd          # Windows CMD 安装程序
+├── Makefile             # 自动化目标 (make install/reinstall/uninstall)
+├── GEMINI.md            # 项目上下文模板文件
+├── packages/            # 本地离线分发包
+│   ├── manifests/       # 适用于所有平台的版本清单
+│   └── binaries/        # (离线模式下需手动创建)
+└── CHANGELOG.md         # 变更日志和发布记录
+```
+
+---
+
+## 🤝 参与贡献与社区
+
+本仓库是原始上游项目 [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli) 的独立社区分叉版本。
+
+**我们的改进：**
+*   🌍 支持文档和指南的多语言本地化。
+*   📦 自主性：具备完全离线安装能力，无需从 Google API 服务器下载。
+*   🛠️ 便利性：添加了 `Makefile`，简化工具生命周期管理。
+*   🛡️ 安全性：针对沙箱环境进行持续的安全改进和漏洞修复。
+
+---
+
+## 📜 法律声明与商标说明
+
+*   **官方链接**: [官方文档仓库](https://github.com/google-antigravity/antigravity-cli) · [官方 CLI 代码库](https://github.com/google-gemini/gemini-cli) · [官方网站](https://antigravity.google)
+*   **使用条款**: [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **分叉版法律地位:**
+> 本存储库是原始客户端的独立非商业副本（社区分叉版本）。它**不是** Google LLC 的官方产品。Google LLC 对此分叉版本的性能、修改或安全性不承担任何责任。
+> 
+> **许可与版权信息:**
+> 原始软件基于 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) 协议分发。所有原始代码的知识产权均归 **Copyright © 2025 Google LLC** 所有。
+> 
+> **商标使用说明:**
+> "Antigravity CLI" 名称及相关徽标仅在合理使用（Customary Use）限制范围内使用，以描述软件的来源、兼容性和功能用途。本分叉项目不声称拥有 Google LLC 任何商标的所有权。
+> 
+> **免责声明:**
+> 本软件按“原样”提供，不提供任何明示或暗示的保证。您需自行承担使用该软件的所有责任和风险。
+
+> [!CAUTION]
+> AI 编码智能体运行具有自主性。在确认执行前，请务必仔细检查其建议的 diff 代码块和执行命令，尤其是在处理系统文件或防火墙配置时。

--- a/README.md
+++ b/README.md
@@ -1,52 +1,66 @@
-# Antigravity CLI
+<p align="center">
+  <b>English</b> | <a href="README-ZH.md">中文</a> | <a href="README-ES.md">Español</a> | <a href="README-FR.md">Français</a> | <a href="README-PT.md">Português</a> | <a href="README-UA.md">Українська</a> | <a href="README-DE.md">Deutsch</a>
+</p>
 
-Antigravity CLI understands your codebase, makes edits with your permission, and executes commands — right from your terminal.
+<p align="center">
+  <img src="https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/agy-cli-demo.gif" alt="Antigravity CLI Logo" width="600" style="border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.25);" />
+</p>
 
-- **Official Docs**: [antigravity.google/docs/cli/overview](https://antigravity.google/docs/cli/overview)
-- **Official Website**: [antigravity.google/product/antigravity-cli](https://antigravity.google/product/antigravity-cli)
+<h1 align="center">🚀 Antigravity CLI</h1>
+<p align="center">
+  <a href="https://antigravity.google/docs/cli/overview">Official Docs</a> · <a href="https://antigravity.google/product/antigravity-cli">Official Website</a>
+</p>
 
-![Antigravity CLI Demo](agy-cli-demo.gif)
+<p align="center">
+  <strong>Community-Fork & Hardened Offline Version of google-antigravity/antigravity-cli with automatic statusline & window title setup</strong>
+</p>
 
----
+<p align="center">
+  <a href="https://github.com/weby-homelab/antigravity-cli"><img src="https://img.shields.io/badge/fork-google--antigravity-8a2be2?style=for-the-badge&logo=github" alt="GitHub Fork" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-1.1.5-success?style=for-the-badge&logo=git" alt="Version" /></a>
+  <a href="https://antigravity.google/terms"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" alt="License" /></a>
+  <img src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey?style=for-the-badge" alt="Supported Platforms" />
+</p>
 
-Antigravity CLI brings the core capabilities of Antigravity 2.0 (multi-step reasoning, multi-file editing, tool calling, and persistent history) directly to your terminal. It is optimized for keyboard-driven workflows and remote SSH sessions with minimal resource overhead.
-
----
-
-## Features at a Glance
-
-| Feature | Antigravity CLI | Antigravity 2.0 |
-| :--- | :--- | :--- |
-| **Primary Focus** | Speed, keyboard efficiency, low overhead | Comprehensiveness, visual orchestration, project management |
-| **Interface** | Terminal User Interface (TUI) | Full Rich GUI Application |
-| **Workflows** | SSH/Remote sessions, keyboard-first | Local workspaces, heavy orchestration |
-| **Agent Engine** | Shared Core Agent Engine | Shared Core Agent Engine |
-
----
-
-## Integration
-
-- **Shared Agent Engine**: Both interfaces run on the same core agent engine. Improvements automatically apply to both.
-- **Shared Settings**: Preferences and permissions sync bidirectionally.
-- **Session Export**: Export terminal sessions to the Antigravity 2.0 GUI to continue working.
+<p align="center">
+  🤖 <b>AI coding agent directly in your terminal</b>. Understands the context of your codebase, creates and edits files, executes secure commands in a sandbox, and solves complex architectural tasks in a single prompt.
+</p>
 
 ---
 
-## Installation
+## ⚡ Quick Start
 
-### macOS / Linux
+### Instant Installation (Offline-first & Zero-dependency)
+This fork downloads precompiled binaries directly from **GitHub Release Assets** (instead of Google API servers). Completely offline installation is also supported if the required archives were preloaded into the `packages/binaries/` folder.
+
+#### 🐧 Linux and 🍎 macOS
 ```bash
-curl -fsSL https://antigravity.google/cli/install.sh | bash
+# Network installation from the fork repository:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash
+
+# OR offline installation from a local repository:
+git clone https://github.com/weby-homelab/antigravity-cli.git
+cd antigravity-cli
+# (Optional: download platform archives to packages/binaries/)
+make install
 ```
 
-### Windows PowerShell
+#### 🪟 Windows PowerShell
 ```powershell
-irm https://antigravity.google/cli/install.ps1 | iex
+# Network installation:
+irm https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.ps1 | iex
+
+# OR offline installation from a cloned repository:
+.\install.ps1
 ```
 
-### Windows CMD
+#### 🪟 Windows CMD
 ```cmd
-curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd
+# Network installation:
+curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.cmd -o install.cmd && install.cmd && del install.cmd
+
+# OR offline installation from a cloned repository:
+install.cmd
 ```
 
 ## Usage
@@ -59,27 +73,184 @@ agy
 
 ---
 
-## Authentication
-
-The CLI authenticates via the system keyring, falling back to Google Sign-In if no active session exists.
-
-- **Local**: Automatically opens your default browser.
-- **Remote / SSH**: Detects SSH sessions and prints an authorization URL to complete login locally.
-- **Sign Out**: Run `/logout` to clear saved credentials.
+## 📋 Key Features
 
 > [!NOTE]
-> For enterprise access, connect your GCP project during onboarding. See the Enterprise page for details.
+> Unlike the original version, this fork is adapted for stable operation in headless/SSH sessions and local home labs.
+
+*   📂 **Multi-file Editing** — Edits multiple files simultaneously in your workspace with prior confirmation of changes.
+*   🔒 **Secure Shell Commands** — Executes any terminal commands in the built-in Docker container (sandbox) or on the host system.
+*   🧠 **Multi-step Reasoning (PAV)** — Independently builds a task execution plan, tests code, and debugs its own errors.
+*   💾 **Persistent Conversation History** — Saves the complete conversation context and workspace state between sessions.
+*   🔌 **Plugin System** — Extend the agent's capabilities with custom *Skills* and MCP (Model Context Protocol) servers.
 
 ---
 
-## Terms of Service & Data Use
+## ⚙️ Configuration
+
+### 1. Project Configuration (`GEMINI.md`)
+Create a `GEMINI.md` file in the root of your project to provide specific context and development rules to the AI agent:
+
+```markdown
+# Project Context
+
+- This project uses FastAPI and Pydantic v2.
+- Always use `model_dump()` instead of the deprecated `dict()`.
+- STRICT RULE: No hardcoded passwords in code. Import all secrets from `.env`.
+```
+
+### 2. Global Settings (`~/.gemini/antigravity-cli/settings.json`)
+The global settings file controls tool execution permissions, statusline/title scripts, and MCP servers:
+
+- **Linux/Unix**: `~/.gemini/antigravity-cli/settings.json`
+- **macOS**: `~/Library/Application Support/antigravity-cli/settings.json`
+- **Windows**: `%APPDATA%\antigravity-cli\settings.json`
+
+```json
+{
+  "toolPermission": "always-proceed",
+  "statusLine": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/statusline.sh"
+  },
+  "title": {
+    "enabled": true,
+    "command": "/home/user/.gemini/antigravity-cli/title.sh"
+  },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}
+```
+
+> [!TIP]
+> For an advanced, responsive statusline with real-time Git status, token meters, model quotas, and power/battery state, check out the **[Antigravity CLI Statusline (Max Edition)](https://github.com/weby-homelab/antigravity-cli-statusline)** plugin.
+
+
+### 3. Specialized Agents
+You can describe custom roles and instructions for AI agents in JSON format. Each agent must have its own directory containing an `agent.json` file:
+
+- **Global Agents (Linux/Unix)**: `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`
+- **Global Agents (macOS)**: `~/Library/Application Support/antigravity-cli/agents/{agent_name}/agent.json`
+- **Global Agents (Windows)**: `%APPDATA%\antigravity-cli\agents\{agent_name}\agent.json`
+- **Local Agents (Project Workspace)**: `{workspace_root}/.agents/agents/{agent_name}/agent.json`
+
+```json
+{
+  "name": "security-reviewer",
+  "description": "Analyzes code for vulnerabilities before commit",
+  "instructions": "Check changes for:\n- OWASP Top 10 vulnerabilities\n- Leakage of API keys or secrets\n- Correctness of firewall/nftables configuration"
+}
+```
+
+---
+
+## 🔐 Authentication Methods
+
+| Method | Command / Variable | Limitations & Features |
+| :--- | :--- | :--- |
+| **Google Auth (Browser)** | Automatically on first `agy` | Standard login. Free limit: 60 req/min, 1000 req/day |
+| **API Key (Offline)** | `export GEMINI_API_KEY="X"` | Recommended for servers and automation |
+| **Vertex AI** | `export GOOGLE_GENAI_USE_VERTEXAI=true` | Enterprise level with Google Cloud cloud infrastructure |
+| **Sign Out** | `/logout` | Clearing local session tokens |
+
+---
+
+## 🔧 Command Reference
+
+### Command Line
+```bash
+agy                              # Start an interactive session
+agy -p "Prompt"                  # One-time execution without entering chat
+agy -c                           # Continue the last incomplete conversation
+agy --conversation <ID>          # Load a session by specific ID
+agy --sandbox                    # Run in an isolated Docker container
+agy update                       # Update binary to the latest version
+agy plugin list                  # List installed plugins
+```
+
+### Slash Commands in Chat Interface
+*   `/help` — Help on available tools.
+*   `/settings` — Interactive settings configuration.
+*   `/usage` — Statistics of spent tokens and quota.
+*   `/diff` — View current unsaved changes in the project.
+*   `/statusline` — Configure terminal status line display.
+
+---
+
+## 🔄 Migration from Gemini CLI
 
 > [!WARNING]
-> AI coding agents are known to have certain security risks, including autonomous code execution, data exfiltration, prompt injection, and supply chain risks. Ensure that you monitor and verify all actions taken by the agent.
+> The original Gemini CLI (`gemini`) is deprecating support for non-enterprise accounts on **June 18, 2026**. Migration to Antigravity CLI is required.
 
-By using Antigravity CLI, you agree to help improve the product by allowing Google to collect and use your Interactions data, subject to the Google Terms of Service and Google Privacy Policy. You can choose to opt out at any time via your settings.
+### Steps for Quick Transition
+1. Install the new client: `curl -fsSL https://raw.githubusercontent.com/weby-homelab/antigravity-cli/main/install.sh | bash`
+2. Migrate local custom agent configuration files (e.g. convert custom agents from YAML inside `~/.gemini/agents/` to JSON files at `~/.gemini/antigravity-cli/agents/{agent_name}/agent.json`).
+3. Update CI/CD configurations in GitHub Actions, replacing `gemini` calls with `agy`.
+4. Uninstall the old library: `npm uninstall -g @google/gemini-cli`
 
-### Legal & Privacy Links
+### Comparison Table
 
-- **Terms of Service**: [antigravity.google/terms](https://antigravity.google/terms)
-- **Privacy Policy**: [policies.google.com/privacy](https://policies.google.com/privacy)
+| Feature | Gemini CLI (Legacy) | Antigravity CLI (Modern) |
+| :--- | :--- | :--- |
+| **Development Platform** | Node.js / TypeScript | Go (Native Compiled Binary) |
+| **Command Name** | `gemini` | `agy` |
+| **Startup Speed** | ~1.2s (Node.js startup) | **~0.05s (instant native startup)** |
+| **Configuration File** | `GEMINI.md` | `GEMINI.md` |
+| **Auto-update** | Via `npm update` | Built-in self-update mechanism |
+| **Support Status** | ⛔ EOL (June 18, 2026) | ✅ Active Development (Upstream) |
+
+---
+
+## 📁 Repository Structure
+
+```
+antigravity-cli/
+├── install.sh           # Installer for Linux/macOS (offline/online)
+├── install.ps1          # Installer for Windows PowerShell (offline/online)
+├── install.cmd          # Installer for Windows CMD
+├── Makefile             # Automation targets (make install/reinstall/uninstall)
+├── GEMINI.md            # Project context file template
+├── packages/            # Local offline distribution
+│   ├── manifests/       # Version manifests for all platforms
+│   └── binaries/        # (Created manually for offline mode)
+└── CHANGELOG.md         # Changelog and release log
+```
+
+---
+
+## 🤝 Contributing & Community
+
+This repository is an independent community fork of the original [google-antigravity/antigravity-cli](https://github.com/google-antigravity/antigravity-cli) project.
+
+**Our Enhancements:**
+*   🌍 Multi-language localization support for docs and guides.
+*   📦 Autonomy: offline installation capability without Google API downloads.
+*   🛠️ Convenience: added `Makefile` for a simplified tool lifecycle.
+*   🛡️ Security: regular bug fixes and improvements to the sandbox environment.
+
+---
+
+## 📜 Legal & Trademark Notice
+
+*   **Official Links**: [Official Documentation Repo](https://github.com/google-antigravity/antigravity-cli) · [Official CLI Codebase](https://github.com/google-gemini/gemini-cli) · [Official Website](https://antigravity.google)
+*   **Terms of Use**: [antigravity.google/terms](https://antigravity.google/terms) · [policies.google.com/privacy](https://policies.google.com/privacy)
+
+> [!IMPORTANT]
+> **Fork Legal Status:**
+> This repository is an independent non-commercial copy (Community Fork) of the original client. It **is not** an official product of Google LLC. Google LLC is not responsible for the performance, modifications, or safety of this fork.
+> 
+> **Licensing & Copyrights:**
+> The original software is distributed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). All original code is the intellectual property of **Copyright © 2025 Google LLC**.
+> 
+> **Trademark Use:**
+> The name "Antigravity CLI" and associated logos are used within Customary Use limits solely to describe the origin, compatibility, and functional purpose of the software. This project does not claim ownership of any Google LLC trademarks.
+> 
+> **Disclaimer of Warranty:**
+> The software is provided on an "AS IS" basis, WITHOUT WARRANTIES OF ANY KIND, either express or implied. You assume all responsibility and risks associated with its use.
+
+> [!CAUTION]
+> AI coding agents work autonomously. Always carefully review the proposed diff blocks and commands before confirming execution, especially when working with system files or firewall configuration.


### PR DESCRIPTION
### Summary of Changes (Fixes #104)

- Adds multi-language README translations for Chinese (`README-ZH.md`), Spanish (`README-ES.md`), French (`README-FR.md`), Portuguese (`README-PT.md`), Ukrainian (`README-UA.md`), and German (`README-DE.md`).
- Standardizes top navigation language switcher across all README variants.
- Fixes broken/outdated documentation links pointing to official URLs (`https://antigravity.google/docs/cli/overview`).
- Includes complete CLI options (`--sandbox`, `--model`, `--conversation`, `/statusline`, `/title`, `/logout`).
