### PR TITLE
feat: add issue auto-assignment, CSAT survey, and stale workflow management

### DIFF
--- a/.github/workflows/auto-assignment.yml
+++ b/.github/workflows/auto-assignment.yml
@@ -1,0 +1,32 @@
+name: auto-assignment
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  welcome:
+    name: Auto Assign Issues
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # Write access needed to add assignees to issues
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Run auto-assignment script
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const script = require('./.github/workflows/scripts/auto-assignment.js')
+            await script({github, context})

--- a/.github/workflows/csat.yml
+++ b/.github/workflows/csat.yml
@@ -1,0 +1,32 @@
+name: 'CSAT survey antigravity-cli'
+
+on:
+  issues:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  welcome:
+    name: CSAT Survey Post
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # Write permission required to post CSAT survey comments on closed issues
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Post CSAT Survey
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const script = require('./.github/workflows/scripts/csat.js')
+            await script({github, context})

--- a/.github/workflows/scripts/auto-assignment.js
+++ b/.github/workflows/scripts/auto-assignment.js
@@ -1,0 +1,39 @@
+/** Automatically assign issues to users in the `assigneesList` 
+ *  on a rotating basis.
+
+  @param {!object}
+    GitHub objects can call GitHub APIs using their built-in library functions.
+    The context object contains issue details.
+*/
+
+module.exports = async ({ github, context }) => {
+  if (!context.payload.issue) {
+    console.log("Not an issue event, skipping.");
+    return;
+  }
+
+  const assigneesList = ["manirajc"];
+  const issueNumber = context.payload.issue.number;
+
+  console.log("assignee list", assigneesList);
+  console.log("entered auto assignment for issue: ", issueNumber);
+  if (!assigneesList.length) {
+    console.log("No assignees found for this repo.");
+    return;
+  }
+  let noOfAssignees = assigneesList.length;
+  let selection = issueNumber % noOfAssignees;
+  let assigneeForIssue = assigneesList[selection];
+
+  console.log(
+    "issue Number = ",
+    issueNumber + " , assigning to: ",
+    assigneeForIssue
+  );
+  return github.rest.issues.addAssignees({
+    issue_number: context.issue.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    assignees: [assigneeForIssue],
+  });
+};

--- a/.github/workflows/scripts/csat.js
+++ b/.github/workflows/scripts/csat.js
@@ -1,0 +1,78 @@
+const CONSTANT_VALUES = {
+  GLOBALS: {
+    LABELS: {
+      BUG: 'bug',
+      COMP_AGENT_CAPABILITIES: 'comp:agent capabilities',
+      COMP_ARTIFACTS: 'comp:artifacts',
+      COMP_AUTH: 'comp:auth',
+      COMP_BILLING_QUOTA: 'comp:billing/quota',
+      COMP_CONVERSATIONS: 'comp:conversations',
+      COMP_CUSTOMIZATIONS: 'comp:customizations',
+      DOCUMENTATION: 'documentation',
+      ENHANCEMENT: 'enhancement',
+      FEATURE_REQUEST: 'feature request',
+      FEEDBACK: 'feedback',
+      GOOD_FIRST_ISSUE: 'good first issue',
+      INSTALL: 'install',
+      PERFORMANCE: 'performance',
+      QUESTION: 'question',
+      REGRESSION_ISSUE: 'regression issue',
+      SECURITY: 'security',
+      STAT_COMMUNITY_SUPPORT: 'stat:community support',
+      SUPPORT: 'support',
+    },
+    STATE: { CLOSED: 'closed' },
+  },
+  MODULE: {
+    CSAT: {
+      YES: 'Yes',
+      NO: 'No',
+      BASE_URL: 'https://docs.google.com/forms/d/e/1FAIpQLSdxycEiO21kzWaArk3OvtDkTh05i3nbgFlj-OckUyqIp0B-iw/viewform?',
+      SATISFACTION_PARAM: 'entry.2005374974=',
+      ISSUEID_PARAM: '&entry.695090381=',
+      MSG: 'Are you satisfied with the resolution of your issue?',
+    }
+  }
+};
+
+/**
+ * Invoked from csat workflow file to post survey link
+ * in closed issue.
+ * @param {!Object.<string,!Object>} github contains pre defined functions.
+ *  context Information about the workflow run.
+ * @return {null}
+ */
+module.exports = async ({ github, context }) => {
+    const issue = context.payload.issue.html_url;
+    
+    // Check if any label matches (case-insensitive) the supported CSAT labels.
+    const supportedLabels = Object.values(CONSTANT_VALUES.GLOBALS.LABELS);
+    const hasMatchingLabel = context.payload.issue.labels.some(label => {
+        const name = label.name.toLowerCase();
+        return supportedLabels.some(supportedLabel => name.includes(supportedLabel));
+    });
+
+    if (hasMatchingLabel) {
+        console.log(`Posting CSAT survey for issue =${issue}`);
+        const baseUrl = CONSTANT_VALUES.MODULE.CSAT.BASE_URL;
+
+        const yesCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+            CONSTANT_VALUES.MODULE.CSAT.YES +
+            CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.YES}</a>`;
+
+        const noCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+            CONSTANT_VALUES.MODULE.CSAT.NO +
+            CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.NO}</a>`;
+
+        const comment = CONSTANT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' +
+            noCsat + '\n';
+        const issueNumber = context.issue.number ?? context.payload.issue.number;
+
+        await github.rest.issues.createComment({
+            issue_number: issueNumber,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment
+        });
+    }
+};

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,57 @@
+name: 'Close stale issues and PRs'
+"on":
+  schedule:
+  - cron: "30 1 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stale:
+    name: 'Close stale issues and PRs'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # Granted write access to label and comment on stale issues
+      pull-requests: write # Granted write access to label and comment on stale pull requests
+    steps:
+    - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7.0.0
+      with:
+        # Comma separated list of labels that can be assigned to issues to exclude them from being marked as stale.
+        exempt-issue-labels: 'override-stale'
+        # Comma separated list of labels that can be assigned to PRs to exclude them from being marked as stale.
+        exempt-pr-labels: "override-stale"
+        # Limit the No. of API calls in one run default value is 30.
+        operations-per-run: 500
+        # Prevent to remove stale label when PRs or issues are updated.
+        remove-stale-when-updated: true
+        # List of labels to remove when issues/PRs unstale. 
+        labels-to-remove-when-unstale: 'stat:awaiting response'
+        # comment on issue if not active for more then 7 days.
+        stale-issue-message: 'This issue has been marked stale because it has no recent activity since 7 days. It will be closed if no further activity occurs. Thank you.'
+        # comment on PR if not active for more then 14 days.
+        stale-pr-message: 'This PR has been marked stale because it has no recent activity since 14 days. It will be closed if no further activity occurs. Thank you.'
+        # comment on issue if stale for more then 7 days.
+        close-issue-message: This issue was closed due to lack of activity after being marked stale for past 7 days.
+        # comment on PR if stale for more then 14 days.
+        close-pr-message: This PR was closed due to lack of activity after being marked stale for past 14 days.
+        # Number of days of inactivity before an Issue Request becomes stale
+        days-before-issue-stale: 7
+        # Number of days of inactivity before a stale Issue is closed
+        days-before-issue-close: 7
+        # reason for closed the issue default value is not_planned
+        close-issue-reason: completed
+        # Number of days of inactivity before a stale PR is closed
+        days-before-pr-close: 14
+        # Number of days of inactivity before an PR Request becomes stale
+        days-before-pr-stale: 14
+        # Check for label to stale or close the issue/PR
+        any-of-labels: 'stat:awaiting response'
+        # override stale to stalled for PR
+        stale-pr-label: 'stale'
+        # override stale to stalled for Issue
+        stale-issue-label: "stale"


### PR DESCRIPTION
## Summary
This PR introduces automated issue lifecycle management workflows for `antigravity-cli`:

1. **Auto-Assignment Workflow** (`auto-assignment.yml` & `auto-assignment.js`):
   - Automatically assigns newly opened issues to repository maintainers on a round-robin rotation.
2. **CSAT Survey Workflow** (`csat.yml` & `csat.js`):
   - Triggers when an issue is closed. If tagged with any supported component/category label, it posts an automated Customer Satisfaction (CSAT) survey link prefilled with the issue URL.
3. **Stale Issue & PR Management** (`stale.yml`):
   - Runs a daily scheduled check to mark inactive items labeled `stat:awaiting response` as `stale` after 7 days (14 days for PRs), and automatically closes them if no response is received.

---

## Changes Included
- [x] `.github/workflows/auto-assignment.yml`
- [x] `.github/workflows/csat.yml`
- [x] `.github/workflows/stale.yml`
- [x] `.github/workflows/scripts/auto-assignment.js`
- [x] `.github/workflows/scripts/csat.js`

## Steps to Clear (STC)

### 1. Test Auto-Assignment
1. Open a new test issue in the repository.
2. Verify that the workflow automatically assigns the issue to the maintainer (`manirajc`).

### 2. Test CSAT Survey
1. Open a test issue and apply a supported label (e.g., `bug`, `documentation`, `question`, or `support`).
2. Close the issue.
3. Verify that an automated comment is posted: *"Are you satisfied with the resolution of your issue? [Yes] [No]"*.
4. Click **Yes** or **No** and verify that it opens the pre-filled Google Form with the correct issue URL.

### 3. Test Stale Bot
1. Confirm `stale.yml` is scheduled for `01:30 UTC` daily.
2. Label an issue with `stat:awaiting response`.
3. Verify that after 7 days of inactivity, the bot marks it `stale`, and closes it after 7 additional days.
