### PR TITLE
fix(examples): remove unsafe eval in title.sh and update documentation links

### DIFF
--- a/examples/statusline/README.md
+++ b/examples/statusline/README.md
@@ -3,7 +3,7 @@
 This directory contains an example script (`statusline.sh`) that demonstrates how to create a custom, dynamic statusline for the Antigravity CLI. 
 
 For more details on how to use and configure the statusline script, please refer to the official public documentation:
-[https://antigravity.google/docs/cli-statusline](https://antigravity.google/docs/cli-statusline)
+[https://antigravity.google/docs/cli/statusline](https://antigravity.google/docs/cli/statusline)
 
 ## How it works
 

--- a/examples/title/README.md
+++ b/examples/title/README.md
@@ -3,7 +3,7 @@
 This directory contains an example script (`title.sh`) that demonstrates how to dynamically customize the window title for the Antigravity CLI based on the agent's current state.
 
 For more details on how to use and configure the title script, please refer to the official public documentation:
-[https://antigravity.google/docs/cli-title](https://antigravity.google/docs/cli-title)
+[https://antigravity.google/docs/cli/title](https://antigravity.google/docs/cli/title)
 
 ## How it works
 

--- a/examples/title/title.sh
+++ b/examples/title/title.sh
@@ -4,12 +4,16 @@ set -euo pipefail
 # Read JSON payload from stdin
 DATA=$(cat)
 
-# Extract fields using jq
-eval $(echo "$DATA" | jq -r '
-  "STATE=\"\(.agent_state // "idle")\"
-   CWD=\"\(.workspace.current_dir // "")\"
-  "
-' 2>/dev/null || echo 'STATE="idle" CWD=""')
+# Extract fields safely using jq without eval
+{
+  read -r STATE
+  read -r CWD
+} <<< "$(
+  jq -r '
+    (.agent_state // "idle"),
+    (.workspace.current_dir // "")
+  ' <<< "$DATA" 2>/dev/null || printf "idle\n\n"
+)"
 
 # Try to extract CitC workspace name from CWD
 if [ -n "$CWD" ]; then


### PR DESCRIPTION
## Summary
- **Security/Safety Fix**: Replaced unsafe `eval` invocation in `examples/title/title.sh` with safe `jq -r` line reading. Previously, `eval $(echo "$DATA" | jq -r ...)` could evaluate arbitrary strings/commands if workspace path contained special characters or quotes.
- **Documentation Fix**: Fixed broken documentation links in `examples/title/README.md` (`cli-title` -> `cli/title`) and `examples/statusline/README.md` (`cli-statusline` -> `cli/statusline`).

## Verification
- Tested `title.sh` with normal JSON payload, CitC workspace path payload, and payload with spaces & quotes.