### PR TITLE
fix(examples): replace unsafe eval in title.sh with safe read block

### DIFF
--- a/examples/title/title.sh
+++ b/examples/title/title.sh
@@ -4,12 +4,16 @@ set -euo pipefail
 # Read JSON payload from stdin
 DATA=$(cat)
 
-# Extract fields using jq
-eval $(echo "$DATA" | jq -r '
-  "STATE=\"\(.agent_state // "idle")\"
-   CWD=\"\(.workspace.current_dir // "")\"
-  "
-' 2>/dev/null || echo 'STATE="idle" CWD=""')
+# Extract fields using jq safely without eval
+{
+  read -r STATE
+  read -r CWD
+} <<< "$(
+  echo "$DATA" | jq -r '
+    (.agent_state // "idle"),
+    (.workspace.current_dir // "")
+  ' 2>/dev/null || printf "idle\n\n"
+)"
 
 # Try to extract CitC workspace name from CWD
 if [ -n "$CWD" ]; then


### PR DESCRIPTION
### Summary of Changes
- Replaced the unsafe `eval $(echo "$DATA" | jq ...)` pattern in `examples/title/title.sh` with a safe multi-line `read -r` block.
- Prevents potential shell command injection if untrusted or malformed directory paths/metadata are passed in the JSON payload.
- Aligns with the robust parsing pattern used in `examples/statusline/statusline.sh`.

### Verification
- Executed `examples/title/title.sh` against simulated agent JSON payloads (`{"agent_state": "working", "workspace": {"current_dir": "/path/to/project"}}`).
- Verified expected clean emoji and workspace title generation without shell evaluation vulnerabilities.