### PR TITLE
Docs/output format flag position

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ After installation, start Antigravity CLI by running:
 agy
 ```
 
+### Machine-readable command output
+
+Use the global `--output-format` flag before the `models` or `agents`
+subcommand to retrieve machine-readable output:
+
+```bash
+agy --output-format json models
+agy --output-format stream-json agents
+```
+
+The flag is global, so the trailing form (`agy models --output-format json`) is
+not supported.
+
 ---
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ agy --output-format json models
 agy --output-format stream-json agents
 ```
 
-The flag is global, so the trailing form (`agy models --output-format json`) is
-not supported.
-
 ---
 
 ## Authentication


### PR DESCRIPTION
## Summary

* Document the confirmed invocation order for the global `--output-format` option.
* Add machine-readable output examples for the `models` and `agents` subcommands.
* Make the existing functionality easier to discover from the README.

## Context

Issue #777 originally reported that `models` and `agents` rejected the `--output-format` option when it was placed after the subcommand.

A maintainer subsequently provided the working invocation order:

```bash
agy --output-format json models
```

The issue was later re-tested with AGY 1.1.15, confirming that placing the global option before the subcommand produced machine-readable output for `models` and `agents`.

This documentation-only change records that confirmed invocation pattern. It does not change command-line parsing or make compatibility guarantees about other argument orderings or future releases.

## Changes

The README now includes these examples:

```bash
agy --output-format json models
agy --output-format stream-json agents
```

## Validation

* Ran `git diff --check`.
* Confirmed that only `README.md` is modified.
* No executable code or command-line behavior is changed.

Addresses #777.